### PR TITLE
store docs by username instead of api key

### DIFF
--- a/agents-backend/agents/main.py
+++ b/agents-backend/agents/main.py
@@ -131,11 +131,12 @@ async def create_report(request: Request):
     try:
         params = await request.json()
         api_key = params.get("api_key")
+        username = params.get("username")
 
         print("create_report", params)
 
         err, report_data = initialise_report(
-            "", api_key, params.get("custom_id"), params.get("other_data")
+            "", api_key, username, params.get("custom_id"), params.get("other_data")
         )
 
         if err is not None:

--- a/agents-backend/agents/partykit-server/server.js
+++ b/agents-backend/agents/partykit-server/server.js
@@ -3,6 +3,7 @@ import { setupWebsocketManager } from "./websocket-manager";
 import * as Y from "yjs";
 
 const docsEndpoint = "ws://agents-python-server:1235/docs";
+
 const getDocsEndpoint = "http://agents-python-server:1235/get_doc";
 
 export default {
@@ -13,6 +14,8 @@ export default {
     const apiToken = params.get("api_token");
     const username = params.get("username");
     const docsBackend = await setupWebsocketManager(docsEndpoint);
+
+    console.log("onConnect", docId, apiToken, username);
 
     return await onConnect(ws, room, {
       load() {
@@ -39,11 +42,6 @@ export default {
                 // Create Uint8Array from bytes
                 uint8Array = new Uint8Array(byteValues);
                 Y.applyUpdate(yDoc, uint8Array);
-                // console.log("\n");
-                // console.log(
-                //   yDoc.getXmlFragment("document-store").firstChild.toJSON()
-                // );
-                // console.log("\n");
               }
 
               return yDoc;
@@ -60,7 +58,6 @@ export default {
           const title = yDoc.getMap("document-title").get("title");
 
           try {
-            console.log(apiToken, username);
             // write to db
             docsBackend.send({
               doc_uint8: JSON.stringify({ bytes: Array.from(yjsState) }),

--- a/agents-backend/docker-setup-files/schema.sql
+++ b/agents-backend/docker-setup-files/schema.sql
@@ -34,6 +34,7 @@ CREATE TABLE public.defog_docs (
     editor_defog_blocks jsonb,
     api_key text NOT NULL,
     "timestamp" text,
+    username text,
     doc_xml text,
     doc_uint8 jsonb,
     doc_title text,

--- a/agents-backend/docker-setup-files/start-python-server.conf
+++ b/agents-backend/docker-setup-files/start-python-server.conf
@@ -2,8 +2,8 @@
 command = python3 -m hypercorn main:app -b 0.0.0.0:1235
 directory = /agents-python-server
 startsecs = 0
-stdout_logfile=/agent-logs
-stderr_logfile=/agent-logs
+stdout_logfile=/agent-logs-out
+stderr_logfile=/agent-logs-err
 killasgroup=true
 stopasgroup=true
 environment=GOOGLE_APPLICATION_CREDENTIALS="/cloud-storage-creds.json"

--- a/components/defog-components/components/agent/AnalysisAgent.jsx
+++ b/components/defog-components/components/agent/AnalysisAgent.jsx
@@ -29,7 +29,7 @@ import ErrorBoundary from "../common/ErrorBoundary";
 import { v4 } from "uuid";
 import { Context } from "../../../../components/common/Context";
 import { createAnalysis, getAnalysis } from "../../../../utils/utils";
-import setupBaseUrl from  "../../../../utils/setupBaseUrl";
+import setupBaseUrl from "../../../../utils/setupBaseUrl";
 import { setupWebsocketManager } from "../../../../utils/websocket-manager";
 
 // the name of the prop where the data is stored for each stage
@@ -45,6 +45,7 @@ const agentRequestTypes = ["clarify", "gen_steps"];
 export const AnalysisAgent = ({
   analysisId,
   apiToken,
+  username,
   updateHook = () => {},
   editor,
 }) => {
@@ -305,7 +306,7 @@ export const AnalysisAgent = ({
         const res = await getAnalysis(analysisId);
         if (!res.success) {
           // create a new analysis
-          analysisData = (await createAnalysis(apiToken, analysisId))
+          analysisData = (await createAnalysis(apiToken, username, analysisId))
             .report_data;
 
           // also have to set docContext in this case
@@ -617,6 +618,7 @@ export const AnalysisAgent = ({
 
                         const res = await createAnalysis(
                           apiToken,
+                          username,
                           newAnalysisId,
                           {
                             other_data: {

--- a/components/docs/DocNav.js
+++ b/components/docs/DocNav.js
@@ -4,7 +4,7 @@ import { GrNewWindow } from "react-icons/gr";
 
 const sidebarWidth = 170;
 
-export default function DocNav({ apiToken, currentDocId }) {
+export default function DocNav({ apiToken, username, currentDocId }) {
   const [sidebarsOpen, setSidebarsOpen] = useState({
     "analysis-list-sidebar": false,
     "db-creds-sidebar": false,
@@ -66,6 +66,7 @@ export default function DocNav({ apiToken, currentDocId }) {
         <div id="nav-other-docs" title="List of other docs of this user">
           <OtherDocs
             apiToken={apiToken}
+            username={username}
             currentDocId={currentDocId}
           ></OtherDocs>
         </div>

--- a/components/docs/OtherDocs.js
+++ b/components/docs/OtherDocs.js
@@ -2,13 +2,13 @@ import React, { Fragment, useEffect, useMemo, useState } from "react";
 import { Dropdown } from "antd";
 import { getAllDocs } from "../../utils/utils";
 
-export default function OtherDocs({ apiToken, currentDocId }) {
+export default function OtherDocs({ apiToken, username, currentDocId }) {
   const [otherDocs, setOtherDocs] = useState([]);
 
   useEffect(() => {
     async function getDocs() {
       try {
-        const json = await getAllDocs(apiToken);
+        const json = await getAllDocs(apiToken, username);
         if (json.success) {
           setOtherDocs(json.docs);
         }

--- a/components/docs/customBlocks/AnalysisBlock.js
+++ b/components/docs/customBlocks/AnalysisBlock.js
@@ -30,6 +30,7 @@ const AnalysisBlock = createReactBlockSpec(
           <AnalysisAgent
             analysisId={block.props.analysisId}
             apiToken={editor.apiToken}
+            username={editor.username}
             editor={editor}
           />
         </ErrorBoundary>

--- a/pages/view-notebooks.js
+++ b/pages/view-notebooks.js
@@ -88,6 +88,7 @@ const ViewNotebooks = () => {
         },
         body: JSON.stringify({
           api_key: context.token,
+          username: context.user,
         }),
       }
     );

--- a/utils/utils.js
+++ b/utils/utils.js
@@ -52,6 +52,7 @@ export const getReport = getAnalysis;
 
 export const createAnalysis = async (
   apiToken,
+  username,
   customId = null,
   bodyData = {}
 ) => {
@@ -66,6 +67,7 @@ export const createAnalysis = async (
       body: JSON.stringify({
         api_key: apiToken,
         custom_id: customId,
+        username: username,
         ...bodyData,
       }),
     });
@@ -78,7 +80,7 @@ export const createAnalysis = async (
 
 export const createReport = createAnalysis;
 
-export const getAllDocs = async (apiToken) => {
+export const getAllDocs = async (apiToken, username) => {
   const urlToConnect = setupBaseUrl("http", "get_docs");
   let response;
   try {
@@ -89,6 +91,7 @@ export const getAllDocs = async (apiToken) => {
       },
       body: JSON.stringify({
         api_key: apiToken,
+        username: username,
       }),
     });
     return response.json();


### PR DESCRIPTION
1. store username while creating docs.
2. get docs based on username instead of api key.
3. separate out recently viewed docs into a different endpoint and call it from the front end instead of partykit which isn't reliable.