### PR TITLE
Init playwright tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ next-env.d.ts
 cloud-storage-creds.json
 genmab_sample.sql
 defog-llm-cloud-function.py
+
+# playwright test stuff
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/README.md
+++ b/README.md
@@ -35,7 +35,35 @@ So I had to also open port `2000`, make an nginx that redirects `http://localhos
 
 The following sections explain how to test portions of the different containers locally. This could be helpful when debugging.
 
-### Agents App
+### Testing the UI
+
+We use [playwright](https://playwright.dev/) to test the UI. The tests are located in `test-ui/`. To run the tests you can directly run the following command:
+
+```bash
+npx playwright test
+# or in UI mode (useful for debugging)
+npx playwright test --ui
+```
+
+This command will start all of the docker containers (if not already running) via [start-containers.sh](test-ui/start-containers.sh) and then run the tests. This is to spin up the full app and enable our tests to verify the end-to-end behavior (including the backend). If you're adding new containers to or removing any containers from our [docker-compose.yaml](docker-compose.yaml), please update the expected container count in [start-containers.sh](test-ui/start-containers.sh) to ensure that our container script expects the right number of containers.
+
+#### Test Structure
+
+Each test file `*.spec.js` should correspond with a route or some component of the UI. Once the test is done, it will output the results in the `test-results` folder, with a highly readable HTML output served at a custom port. You can view the results by opening the HTML file in your browser.
+
+#### VSCode Debugging
+
+You can also install the playwright extension for VSCode and debug the tests from there.
+
+#### Codegen for Tests
+
+You can use the following command to generate the playwright code from a set of recorded actions on the actual UI:
+
+```sh
+npx playwright codegen http://localhost:1234
+```
+
+### Running Agents App Locally
 
 This project requires Node.js. If you don't have it, you can follow the instructions [here](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm#using-a-node-installer-to-install-nodejs-and-npm).
 
@@ -56,4 +84,5 @@ pnpm dev
 bun dev
 ```
 
-Open [http://localhost:1234](http://localhost:1234) with your browser to see the result.
+Open [http://localhost:1234](http://localhost:1234) with your browser to see the result. Note that full functionality will not be available unless the backend is also running.
+

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,8 @@
       },
       "devDependencies": {
         "@next/bundle-analyzer": "^13.4.17",
+        "@playwright/test": "^1.41.1",
+        "@types/node": "^20.11.6",
         "babel-plugin-styled-components": "^2.1.4",
         "eslint": "^8.30.0",
         "eslint-config-next": "^12.0.4",
@@ -3177,6 +3179,21 @@
         "node": ">=12"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.41.1.tgz",
+      "integrity": "sha512-9g8EWTjiQ9yFBXc6HjCWe41msLpxEX0KhmfmPl9RPLJdfzL4F0lg2BdJ91O9azFdl11y1pmpwdjBiSxvqc+btw==",
+      "dev": true,
+      "dependencies": {
+        "playwright": "1.41.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/@polka/url": {
       "version": "1.0.0-next.24",
       "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.24.tgz",
@@ -3833,9 +3850,9 @@
       "integrity": "sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g=="
     },
     "node_modules/@types/node": {
-      "version": "20.10.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.3.tgz",
-      "integrity": "sha512-XJavIpZqiXID5Yxnxv3RUDKTN5b81ddNC3ecsA0SoFXz/QU8OGBwZGMomiq0zw+uuqbL/krztv/DINAQ/EV4gg==",
+      "version": "20.11.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.6.tgz",
+      "integrity": "sha512-+EOokTnksGVgip2PbYbr3xnR7kZigh4LbybAfBAw5BpnQ+FqBYUsvCEjYd70IXKlbohQ64mzEYmMtlWUY8q//Q==",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -10721,6 +10738,50 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.41.1.tgz",
+      "integrity": "sha512-gdZAWG97oUnbBdRL3GuBvX3nDDmUOuqzV/D24dytqlKt+eI5KbwusluZRGljx1YoJKZ2NRPaeWiFTeGZO7SosQ==",
+      "dev": true,
+      "dependencies": {
+        "playwright-core": "1.41.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.41.1.tgz",
+      "integrity": "sha512-/KPO5DzXSMlxSX77wy+HihKGOunh3hqndhqeo/nMxfigiKzogn8kfL0ZBDu0L1RKgan5XHCPmn6zXd2NUJgjhg==",
+      "dev": true,
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,8 @@
   },
   "devDependencies": {
     "@next/bundle-analyzer": "^13.4.17",
+    "@playwright/test": "^1.41.1",
+    "@types/node": "^20.11.6",
     "babel-plugin-styled-components": "^2.1.4",
     "eslint": "^8.30.0",
     "eslint-config-next": "^12.0.4",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,77 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+export default defineConfig({
+  testDir: './test-ui',
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://127.0.0.1:3000',
+
+    /* Collect trace when retrying the failed test. See https://playwright.dev/docs/trace-viewer */
+    trace: 'on-first-retry',
+  },
+
+  /* Configure projects for major browsers */
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+
+    {
+      name: 'firefox',
+      use: { ...devices['Desktop Firefox'] },
+    },
+
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+
+    /* Test against mobile viewports. */
+    // {
+    //   name: 'Mobile Chrome',
+    //   use: { ...devices['Pixel 5'] },
+    // },
+    // {
+    //   name: 'Mobile Safari',
+    //   use: { ...devices['iPhone 12'] },
+    // },
+
+    /* Test against branded browsers. */
+    // {
+    //   name: 'Microsoft Edge',
+    //   use: { ...devices['Desktop Edge'], channel: 'msedge' },
+    // },
+    // {
+    //   name: 'Google Chrome',
+    //   use: { ...devices['Desktop Chrome'], channel: 'chrome' },
+    // },
+  ],
+
+  /* Run your local dev server before starting the tests */
+  webServer: {
+    command: './test-ui/start-containers.sh',
+    url: 'http://127.0.0.1:1234',
+    reuseExistingServer: !process.env.CI,
+  },
+});

--- a/test-ui/login.spec.ts
+++ b/test-ui/login.spec.ts
@@ -1,0 +1,32 @@
+const { test, expect } = require('@playwright/test');
+
+test.describe('Login page', () => {
+    test('redirects to /login if user, token, or userType is missing', async ({ page }) => {
+        await page.goto('http://localhost:1234');
+        await page.evaluate(() => {
+            // remove user token userType from localStorage
+            localStorage.removeItem('user');
+            localStorage.removeItem('token');
+            localStorage.removeItem('userType');
+        });
+        await page.waitForNavigation();
+
+        // Check that we've been redirected to /login
+        expect(page.url()).toBe('http://localhost:1234/login');
+    });
+    test('admin login', async ({ page }) => {
+        await page.goto('http://localhost:1234/login');
+        await page.getByLabel('Username').click();
+        await page.getByLabel('Username').fill('admin');
+        await page.getByLabel('Password').click();
+        await page.getByLabel('Password').fill('admin');
+        await page.getByRole('button', { name: 'Log In' }).click();
+        await page.waitForNavigation();
+        // Check that we've been redirected to /
+        expect(page.url()).toBe('http://localhost:1234/');
+        await page.waitForNavigation();
+        // Check that we've been redirected to /extract-metadata (special case for 'admin' user)
+        expect(page.url()).toBe('http://localhost:1234/extract-metadata');
+        await expect(page.getByRole('heading')).toContainText(['Extract Metadata']);
+      });
+    });

--- a/test-ui/start-containers.sh
+++ b/test-ui/start-containers.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Define the expected number of containers. Update this if you add more containers to the docker-compose file.
+expected_count=5
+
+# Get the count of containers with names starting with 'defog-self-hosted-agents-'
+container_count=$(docker container ls -a | grep 'defog-self-hosted-agents-' | wc -l)
+
+# Check if the count is equal to the expected count
+if [ "$container_count" -eq "$expected_count" ]; then
+  # print out a list of the container names
+  echo "There are $container_count containers with names starting with 'defog-self-hosted-agents-'."
+else
+  echo "There are $container_count containers with names starting with 'defog-self-hosted-agents-'. Starting docker-compose..."
+  # Run docker-compose up -d
+  docker-compose up -d
+fi
+
+# print out a list of the container names
+echo "The containers are:"
+docker container ls -a | grep 'defog-self-hosted-agents-' | awk '{print $NF}'


### PR DESCRIPTION
This PR initializes the folder structure and setup for our end-to-end UI tests.
We use [playwright](https://playwright.dev/) for running the tests and I've included a simple example to start with. Each route / functionality should have its dedicated `*.spec.ts` file, and I'll be adding more later if this looks good. To run the tests:
```sh
npx playwright test
```