### PR TITLE
Notebook markdown test

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,38 @@ So I had to also open port `2000`, make an nginx that redirects `http://localhos
 
 The following sections explain how to test portions of the different containers locally. This could be helpful when debugging.
 
-### Running Agents App Locally
+### Testing the UI
+
+We use [playwright](https://playwright.dev/) to test the UI. The tests are located in `test-ui/`. To run the tests you can directly run the following command:
+
+```bash
+# if first time running, install playwright:
+npx playwright install
+# then run the tests:
+npx playwright test
+# or in UI mode (useful for debugging)
+npx playwright test --ui
+```
+
+This command will start all of the docker containers (if not already running) via [start-containers.sh](test-ui/start-containers.sh) and then run the tests. This is to spin up the full app and enable our tests to verify the end-to-end behavior (including the backend). If you're adding new containers to or removing any containers from our [docker-compose.yaml](docker-compose.yaml), please update the expected container count in [start-containers.sh](test-ui/start-containers.sh) to ensure that our container script expects the right number of containers.
+
+#### Test Structure
+
+Each test file `*.spec.js` should correspond with a route or some component of the UI. Once the test is done, it will output the results in the `test-results` folder, with a highly readable HTML output served at a custom port. You can view the results by opening the HTML file in your browser.
+
+#### VSCode Debugging
+
+You can also install the playwright extension for VSCode and debug the tests from there.
+
+#### Codegen for Tests
+
+You can use the following command to generate the playwright code from a set of recorded actions on the actual UI:
+
+```sh
+npx playwright codegen http://localhost:1234
+```
+
+### Running Front-end Locally
 
 This project requires Node.js. If you don't have it, you can follow the instructions [here](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm#using-a-node-installer-to-install-nodejs-and-npm).
 

--- a/test-ui/notebooks.spec.ts
+++ b/test-ui/notebooks.spec.ts
@@ -1,0 +1,39 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Notebooks page', () => {
+  test('Notebook Creation and Basic Analysis', async ({ page }) => {
+    await page.goto('http://localhost:1234/');
+    // set the auth variables in localStorage so that we don't get redirected to /login
+    await page.evaluate(() => {
+        localStorage.setItem('defogUser', 'admin');
+        localStorage.setItem('defogToken', 'bdbe4d376e6c8a53a791a86470b924c0715854bd353483523e3ab016eb55bcd0');
+        localStorage.setItem('defogUserType', 'admin');
+    });
+    // get the url path of the new window
+    const context = page.context();
+    const page1 = await context.newPage();
+    await page1.goto('http://localhost:1234/doc?docId=new');
+    await page1.waitForLoadState();
+    await page1.waitForSelector('#nav-other-docs');
+    await expect(page1.getByText('New')).toBeVisible();
+    await expect(page1.getByText('Open')).toBeVisible();
+    await expect(page1.getByText('Past analyses')).toBeVisible();
+
+    // test out markdown component (H1)
+    // select the first empty block, type '/' to open the menu, select 'H1', and type in 'H1'
+    await page1.locator('.tiptap').first().click();
+    await page1.locator('.tiptap').first().press('/');
+    // await page1.getByText('Headings', { exact: true }).waitFor({ state: 'visible' });
+    await page1.getByRole('menuitem', { name: 'Heading Used for a top-level' }).click();
+    await page1.locator('.bn-block').first().fill('H1');
+    await page1.locator('.bn-block').first().press('Enter');
+    await expect(page1.getByRole('heading', { name: 'H1' })).toContainText('H1');
+
+    // test out markdown component (H2)
+    // select the same block, type '/' to open the menu, select 'H2', and type in 'H2'
+    await page1.locator('.bn-block-content').nth(1).press('/');
+    await page1.getByRole('menuitem', { name: 'Heading 2 Used for key' }).click();
+    await page1.locator('div:nth-child(1) > .bn-block > .bn-block-content').fill('H2');
+    await expect(page1.getByRole('heading', { name: 'H2' })).toContainText('H2');
+  });
+});


### PR DESCRIPTION
Added tests for Notebook's markdown components for a start (before diving into the more complicated agents stuff.

Not sure what is the best role to use to select and navigate between components; had a lot of issues trying to select the second "block" with `await page1.locator('.bn-block-content').nth(1).press('/');`; it somehow selects the 1st block, even though nth(1) is supposed to select the 2nd. Test is the max I got working for now, but it seems like it does validate the standard markdown for now.