### PR TITLE
bug fixes: strategy and centralising websockets.

### DIFF
--- a/agents-backend/src/doc_endpoints.py
+++ b/agents-backend/src/doc_endpoints.py
@@ -429,7 +429,12 @@ async def rerun_step(websocket: WebSocket):
             # get steps from db
             err, analysis_data = get_report_data(analysis_id)
             if err:
-                return {"success": False, "error_message": err}
+                return {
+                    "success": False,
+                    "error_message": err,
+                    "tool_run_id": tool_run_id,
+                    "analysis_id": analysis_id,
+                }
 
             metadata_dets = get_metadata()
             glossary = metadata_dets["glossary"]
@@ -444,13 +449,23 @@ async def rerun_step(websocket: WebSocket):
             }
 
             if err:
-                return {"success": False, "error_message": err}
+                return {
+                    "success": False,
+                    "error_message": err,
+                    "tool_run_id": tool_run_id,
+                    "analysis_id": analysis_id,
+                }
 
             steps = analysis_data["gen_steps"]
             if steps["success"]:
                 steps = steps["steps"]
             else:
-                return {"success": False, "error_message": steps["error_message"]}
+                return {
+                    "success": False,
+                    "error_message": steps["error_message"],
+                    "tool_run_id": tool_run_id,
+                    "analysis_id": analysis_id,
+                }
 
             print([s["inputs"] for s in steps])
             async for err, reran_id, new_data in rerun_step_and_dependents(
@@ -464,6 +479,7 @@ async def rerun_step(websocket: WebSocket):
                             {
                                 "success": True,
                                 "tool_run_id": reran_id,
+                                "analysis_id": analysis_id,
                                 "tool_run_data": new_data,
                             },
                             websocket,
@@ -477,6 +493,7 @@ async def rerun_step(websocket: WebSocket):
                                 "pre_tool_run_message": new_data.get(
                                     "pre_tool_run_message"
                                 ),
+                                "analysis_id": analysis_id,
                             },
                             websocket,
                         )
@@ -487,6 +504,7 @@ async def rerun_step(websocket: WebSocket):
                             "success": False,
                             "error_message": err,
                             "tool_run_id": reran_id,
+                            "analysis_id": analysis_id,
                         },
                         websocket,
                     )

--- a/agents-backend/src/main.py
+++ b/agents-backend/src/main.py
@@ -201,7 +201,7 @@ async def websocket_endpoint(websocket: WebSocket):
 
                 resp = {}
                 resp["request_type"] = request_type
-                resp["report_id"] = report_data_manager.report_data["report_id"]
+                resp["analysis_id"] = report_data_manager.report_data["report_id"]
 
                 toolboxes = (
                     data.get("toolboxes")
@@ -258,7 +258,11 @@ async def websocket_endpoint(websocket: WebSocket):
 
                             # send done true
                             await websocket.send_json(
-                                {"done": True, "request_type": request_type}
+                                {
+                                    "done": True,
+                                    "request_type": request_type,
+                                    "analysis_id": report_id,
+                                }
                             )
                         else:
                             # if not a generator agent
@@ -278,6 +282,7 @@ async def websocket_endpoint(websocket: WebSocket):
                                 "done": True,
                                 "success": False,
                                 "error_message": str(e)[:300],
+                                "analysis_id": report_id,
                             }
                         )
 
@@ -292,6 +297,7 @@ async def websocket_endpoint(websocket: WebSocket):
                     {
                         "success": False,
                         "error_message": "Something went wrong. Please try again or contact us if this persists.",
+                        "analysis_id": report_id,
                     }
                 )
     except WebSocketDisconnect as e:

--- a/components/docs/DocContext.js
+++ b/components/docs/DocContext.js
@@ -6,6 +6,11 @@ export const DocContext = createContext({
     toolboxes: [],
     metadata: {},
   },
+  socketManagers: {
+    mainMgr: null,
+    rerunMgr: null,
+    toolMgr: null,
+  },
   dbCreds: {
     dbType: "postgres",
     host: "",

--- a/dockerfile.agents-partykit
+++ b/dockerfile.agents-partykit
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:20.11.1
 
 WORKDIR partykit-server
 

--- a/utils/websocket-manager.js
+++ b/utils/websocket-manager.js
@@ -69,11 +69,25 @@ export function setupWebsocketManager(
     log = on;
   }
 
+  function addEventListener(event, cb) {
+    if (socket) {
+      socket.addEventListener(event, cb);
+    }
+  }
+
+  function removeEventListener(event, cb) {
+    if (socket) {
+      socket.removeEventListener(event, cb);
+    }
+  }
+
   return connect()
     .then(() => {
       return {
         send,
         reconnect,
+        addEventListener,
+        removeEventListener,
         changeUrlAndReconnect,
         isConnected,
         logging,


### PR DESCRIPTION
1. centralise websockets
3. downgrade node to v20 to prevent http strategy error with miniflare. https://github.com/cloudflare/workers-sdk/pull/5201/files
4. always return analysis id in returns from the backend to allow filtering on the front end.

I have tested all the three main websockets: re run, main analysis websocket, and tool editing ones. Appreciate all testing!