### PR TITLE
Manas/fix websocket reconnection

### DIFF
--- a/frontend/components/docs/Doc.js
+++ b/frontend/components/docs/Doc.js
@@ -107,12 +107,6 @@ export function Editor({ docId = null, username = null, apiToken = null }) {
         },
       });
 
-      window.managers = {
-        mainManager: mgr,
-        reRunManager: rerunMgr,
-        toolSocketManager: toolSocketManager,
-      };
-
       // add to recently viewed docs for this user
       await fetch(recentlyViewedEndpoint, {
         method: "POST",


### PR DESCRIPTION
Uses a `disabled` property on event listeners to re-add them on socket-reconnect instead of removing array elements (which change indices)