### PR TITLE
Added a function to preview the first 5 rows in a given table

### DIFF
--- a/backend/integration_routes.py
+++ b/backend/integration_routes.py
@@ -437,6 +437,7 @@ async def preview_table(request: Request):
     """
     Preview the first 10 rows of a table, given the table name and standard parameters of token, key_name, and temp
     Also sanitizes the table name to prevent SQL injection
+    KNOWN ISSUE: Does not work if the table name has a double quote in it
     """
     params = await request.json()
     token = params.get("token")
@@ -482,6 +483,9 @@ async def preview_table(request: Request):
         sql_query = f'SELECT * FROM "{table_name}" LIMIT 10'
     else:
         sql_query = f'SELECT TOP 10 * FROM "{table_name}"'
+
+    print("Executing preview table query", flush=True)
+    print(sql_query, flush=True)
 
     try:
         colnames, data, _ = await asyncio.to_thread(


### PR DESCRIPTION
To verify that this is working, first get docker up

```bash
docker compose up --build
```

**Testing with a valid table name**
Then, make a request to the new `/integration/preview_table` endpoint
```python
import requests
endpoint = "http://localhost/integration/preview_table"
token = "bdbe4d376e6c8a53a791a86470b924c0715854bd353483523e3ab016eb55bcd0" # default admin token
key_name = "REPLACE_W_YOUR_KEYNAME"
table_name = "REPLACE_W_VALID_TABLE_NAME"
r = requests.post(endpoint, json={"token": token, "key_name": key_name, "table_name": table_name})
r.json()
```
If your table name is valid, you will get a JSON object back with the columns `data` and `columns`


**Testing with an invalid table name**
If your table name is invalid, you will get an error that either says "error executing query" or "invalid table name"

```python
import requests
endpoint = "http://localhost/integration/preview_table"
token = "bdbe4d376e6c8a53a791a86470b924c0715854bd353483523e3ab016eb55bcd0" # default admin token
key_name = "REPLACE_W_YOUR_KEYNAME"
table_name = "impossible_table_that_does_not_exist"
r = requests.post(endpoint, json={"token": token, "key_name": key_name, "table_name": table_name})
r.json()
# {'error': 'error executing query'}
```

**Testing with an table name that could be a security hazard**
```python
import requests
endpoint = "http://localhost/integration/preview_table"
token = "bdbe4d376e6c8a53a791a86470b924c0715854bd353483523e3ab016eb55bcd0" # default admin token
key_name = "REPLACE_W_YOUR_KEYNAME"
table_name = "temp_table; DROP temp_table;"
r = requests.post(endpoint, json={"token": token, "key_name": key_name, "table_name": table_name})
r.json()
# {'error': 'invalid table name'}
```

There is a fun section around what we are doing to prevent SQL injections in the comments! Ordinarily, we would just use the client library (like `psycopg2`) or the SQLAlchemy format the query. But in this case, doing that will be quite annoying since we would have to rewrite a lot of code with every single connector separately to execute this function.

So instead, we just do 2 things:
1. put double quotes around the table name to make sure users can't do anything sneaky
2. restrict the characters in the table name to just alphanumerics, spaces, and periods. We _could_ also allow double quotes (since double quotes are [technically supported](https://www.postgresql.org/docs/7.0/syntax525.htm) in postgres table names). But these are quite rare and `preview_table` is a not an essential function. So leaving this be as a known issue

Lastly, I have added a `KNOWN_ISSUE` keyword to the docstring. This should become a standard practice moving forward, so that all known issues are well documented and can be fixed later.