### PR TITLE
Infra fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,6 @@ defog_metadata.csv
 
 # reports
 oracle/reports
+
+# agents-assets
+agents-assets/

--- a/backend/agents/planner_executor/tool_helpers/core_functions.py
+++ b/backend/agents/planner_executor/tool_helpers/core_functions.py
@@ -1,27 +1,11 @@
-from typing import Dict, List
-import tiktoken
-from datetime import date
-import pandas as pd
 import base64
 import os
+from typing import Dict, List
 
-# these are needed for the exec_code function
 import pandas as pd
+import tiktoken
 
-from openai import AsyncOpenAI
-
-# get OPENAI_API_KEY from env
-
-openai = None
-
-if (
-    os.environ.get("OPENAI_API_KEY") is None
-    or os.environ.get("OPENAI_API_KEY") == "None"
-    or os.environ.get("OPENAI_API_KEY") == ""
-):
-    print("OPENAI_API_KEY not found in env")
-else:
-    openai = AsyncOpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
+from utils_llm import llm_call
 
 report_assets_dir = os.environ.get("REPORT_ASSETS_DIR", "./report_assets")
 
@@ -109,10 +93,6 @@ async def analyse_data(
     """
     Generate a short summary of the results for the given qn.
     """
-    if not openai:
-        yield {"success": False, "model_analysis": "NONE"}
-        return
-
     if data is None:
         yield {"success": False, "model_analysis": "No data found"}
         return
@@ -167,12 +147,11 @@ async def analyse_data(
             },
         ]
 
-    completion = await openai.chat.completions.create(
+    completion = await llm_call(
         model="gpt-4o",
         messages=messages,
         temperature=0,
         seed=42,
-        stream=True,
         max_tokens=400,
     )
 

--- a/backend/startup.sh
+++ b/backend/startup.sh
@@ -1,3 +1,12 @@
+# create empty report assets dirs
+mkdir -p /agents-assets/report-assets
+mkdir -p /agents-assets/report-assets/boxplots 
+mkdir -p /agents-assets/report-assets/datasets 
+mkdir -p /agents-assets/report-assets/heatmaps 
+mkdir -p /agents-assets/report-assets/linechart 
+mkdir -p /agents-assets/report-assets/linecharts
+touch /agent-logs-out
+
 python3 create_sqlite_tables.py
 python3 create_admin_user.py
 python3 add_tools_to_db.py

--- a/backend/utils_llm.py
+++ b/backend/utils_llm.py
@@ -1,0 +1,13 @@
+import os
+
+from generic_utils import make_request
+
+DEFOG_BASE_URL = os.environ.get("DEFOG_BASE_URL", "https://api.defog.ai")
+
+async def llm_call(model, messages, **kwargs):
+    result = await make_request(DEFOG_BASE_URL + "/llm_call", {
+        "model": model,
+        "messages": messages,
+        **kwargs
+    })
+    return result

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -60,7 +60,7 @@ services:
     ports:
       - "1235:1235"
     volumes:
-      - agents-assets:/agents-assets/
+      - ./agents-assets:/agents-assets
       - ./backend:/backend
     depends_on:
       - agents-partykit
@@ -116,7 +116,6 @@ services:
 
 volumes:
   agents-postgres:
-  agents-assets:
   redis-data:
 
 

--- a/dockerfile.agents-python-server
+++ b/dockerfile.agents-python-server
@@ -13,16 +13,5 @@ RUN pip install -r ./requirements.txt
 # expose python server port
 EXPOSE 1235
 
-# create empty report assets dirs
-RUN mkdir -p /agents-assets/report-assets
-RUN mkdir -p /agents-assets/report-assets/boxplots 
-RUN mkdir -p /agents-assets/report-assets/datasets 
-RUN mkdir -p /agents-assets/report-assets/heatmaps 
-RUN mkdir -p /agents-assets/report-assets/linechart 
-RUN mkdir -p /agents-assets/report-assets/linecharts
-RUN touch /agent-logs-out
-
-ENV PYTHONUNBUFFERED=true
-
 # start startup script
 CMD sh ./startup.sh


### PR DESCRIPTION
### Changes
- shifted openai calls to `${DEFOG_BASE_URL}/llm_call`. the structure follows the normal openai api specs, and only model and messages are compulsory parameters for now. will implement the `/llm_call` endpoint in defog-backend-python in a separate PR. currently the only place where we have an explicit openai call is in the `analyse_data` websocket endpoint.
- mount agents-assets to a local directory (`agents-assets`) to facilitate easy exploring of the files generated
- shifted subfolder creation to `startup.sh` since anything done to the mounted path in dockerfile.agents-python-server will be overriden by whatever is in the actual file system's folder
- gitignore `agents-assets`

### Testing
Was unable to test it fully as the `analyse_data` websocket endpoint is buggy at the moment (hence we were unable to reach the part where it calls the openai backend), see server logs:
```
...
2024-08-14 11:28:19 INFO:root:getting tool run: 070cee84-b1a2-4c81-a064-6fd2cf84ac0e
2024-08-14 11:28:19 Traceback (most recent call last):
2024-08-14 11:28:19   File "/backend/doc_endpoints.py", line 550, in analyse_data_endpoint
2024-08-14 11:28:19     df = pd.read_csv(StringIO(data.get("data")))
2024-08-14 11:28:19 TypeError: initial_value must be str or None, not dict
```
This has to do with the data sent over websockets being a dict and not a string. We won't fix this now, due to the ongoing migration from websockets to individual REST API calls.