### PR TITLE
Allow source selection

### DIFF
--- a/backend/oracle/core.py
+++ b/backend/oracle/core.py
@@ -154,6 +154,9 @@ async def gather_context(
     # TODO implement this function
     # dummy print statement for now
     print(f"Gathering context for report {report_id}")
+    print("Got the following sources:")
+    for source in inputs.get("sources", []):
+        print(f"{source}")
     # sleep for a random amount of time to simulate work
     await sleep(random.random() * 2)
     return {"context": "context gathered"}

--- a/frontend/components/oracle/Sources.js
+++ b/frontend/components/oracle/Sources.js
@@ -1,10 +1,11 @@
+import { useState } from "react";
+import { PlusOutlined, CheckOutlined } from "@ant-design/icons";
 import Image from "next/image";
 
-export default function Sources({ sources }) {
+export default function Sources({ sources, setSources }) {
   if (sources.length === 0) {
     return null;
   }
-  console.log(sources);
   return (
     <div className="bg-white flex w-full flex-col">
       <div className="flex items-start gap-4 pb-3">
@@ -14,36 +15,62 @@ export default function Sources({ sources }) {
       </div>
       <div className="flex w-full items-center overflow-x-scroll gap-6 pb-3">
         {sources.map((source) => (
-          <SourceCard source={source} key={source.url} />
+          <SourceCard source={source} setSources={setSources} />
         ))}
       </div>
     </div>
   );
 }
 
-const SourceCard = ({ source }) => {
+const SourceCard = ({ source, setSources }) => {
+  const [selected, setSelected] = useState(source.selected);
+  const handleSelect = () => {
+    setSelected(!selected);
+    setSources((prevSources) =>
+      prevSources.map((prevSource) => {
+        if (prevSource.position === source.position) {
+          return { ...prevSource, selected: !selected };
+        }
+        return prevSource;
+      })
+    );
+  };
   return (
-    <div className="flex h-[79px] w-full items-center gap-2.5 rounded-lg border border-gray-100 px-1.5 py-1 shadow-md">
-      <div className="shrink-0">
-        <Image
-          unoptimized
-          src={`https://www.google.com/s2/favicons?domain=${source.link}&sz=128`}
-          alt={source.link}
-          className="rounded-full p-1"
-          width={36}
-          height={36}
-        />
-      </div>
-      <div className="flex min-w-0 max-w-[192px] flex-col justify-center gap-1">
-        <h6 className="line-clamp-2 text-xs font-light">{source.title}</h6>
-        <a
-          target="_blank"
-          rel="noopener noreferrer"
-          href={source.link}
-          className="truncate text-xs font-light text-[#1B1B16]/30"
+    <div
+      className={`"flex h-[79px] w-full items-center gap-2.5 rounded-lg border border-gray-100 px-1.5 py-1 shadow-md ${selected ? "bg-gray-100 opacity-50" : "bg-white"}`}
+    >
+      <div className="flex items-center relative">
+        <span className="shrink-0">
+          <Image
+            unoptimized
+            src={`https://www.google.com/s2/favicons?domain=${source.link}&sz=128`}
+            alt={source.link}
+            className="rounded-full p-1"
+            width={36}
+            height={36}
+          />
+        </span>
+        <span className="flex min-w-0 max-w-[192px] flex-col justify-center gap-1 ml-2 mt-2">
+          <h6 className="line-clamp-2 text-xs font-light">{source.title}</h6>
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            href={source.link}
+            className="truncate text-xs font-light text-[#1B1B16]/30"
+          >
+            {source.link}
+          </a>
+        </span>
+        <div
+          className="ml-auto cursor-pointer top-2 right-2"
+          onClick={handleSelect}
         >
-          {source.link}
-        </a>
+          {selected ? (
+            <CheckOutlined style={{ color: "green" }} />
+          ) : (
+            <PlusOutlined />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/frontend/pages/oracle-frontend.js
+++ b/frontend/pages/oracle-frontend.js
@@ -80,7 +80,12 @@ function OracleDashboard() {
     if (res.ok) {
       const data = await res.json();
       // we only use the list of organic search results, discarding the rest for now
-      setSources(data.organic);
+      const sources = data.organic;
+      // add a selected field to each source
+      sources.forEach((source) => {
+        source.selected = false;
+      });
+      setSources(sources);
     } else {
       console.error("Failed to fetch sources");
     }
@@ -158,6 +163,8 @@ function OracleDashboard() {
   const generateReport = async () => {
     // generate a report
     const token = localStorage.getItem("defogToken");
+    const selectedSources = sources.filter((source) => source.selected);
+    console.log(selectedSources);
     const res = await fetch(setupBaseUrl("http", `oracle/begin_generation`), {
       method: "POST",
       headers: {
@@ -167,6 +174,7 @@ function OracleDashboard() {
         token,
         key_name: apiKeyName,
         question: userTask,
+        sources: selectedSources,
       }),
     });
 
@@ -277,12 +285,11 @@ function OracleDashboard() {
           )}
 
           <div className="mt-6">
-            <Sources sources={sources} />
+            <Sources sources={sources} setSources={setSources} />
           </div>
 
           <Button
             className="bg-purple-500 text-white py-2 px-4 rounded-lg hover:bg-purple-600"
-            disabled={!ready}
             onClick={generateReport}
           >
             Generate


### PR DESCRIPTION
In this PR, we update the `SourceCard` to support the selection of sources and pass selected sources to the backend. I'm not sure if I've done it right by passing through the `setSources` function all the way down to each `SourceCard`, please correct me if I'm using the wrong design pattern here. Each source has a `position`, so we use that as the index to find individual sources and update their `selected` attribute. Finally, when the user clicks on `Generate`, we will pass only the selected sources over to the backend for context gathering.

Tested and demonstrated in this loom video:
https://www.loom.com/share/1e349be616f543bc827c1b923a7f997b?sid=56283afe-26e0-4570-9087-8760f76a412e

docker logs for the backend server confirming the selected sources were passed in correctly:
```
2024-08-19 18:36:51 [2024-08-19 10:36:51,459: WARNING/ForkPoolWorker-7] Starting celery task for bdbe4d376e6c8a53a791a86470b924c0715854bd353483523e3ab016eb55bcd0 at 2024-08-19 10:36:51.458932
2024-08-19 18:36:51 [2024-08-19 10:36:51,459: WARNING/ForkPoolWorker-7] Gathering context for report 16
2024-08-19 18:36:51 [2024-08-19 10:36:51,459: WARNING/ForkPoolWorker-7] Got the following sources:
2024-08-19 18:36:51 [2024-08-19 10:36:51,459: WARNING/ForkPoolWorker-7] {'title': '12 Best Cashback Credit Cards in Singapore (Jun 2024)', 'link': 'https://sg.finance.yahoo.com/news/11-best-cashback-credit-cards-000024719.html', 'snippet': '1. Best cashback credit cards in Singapore 2024 · 2. UOB Absolute Cashback Card · 3. Citi Cash Back+ Card · 4. HSBC Visa Platinum Credit Card · 5.', 'date': '16 hours ago', 'attributes': {'Missing': 'dual- households'}, 'position': 1, 'selected': True}
2024-08-19 18:36:51 [2024-08-19 10:36:51,459: WARNING/ForkPoolWorker-7] {'title': 'Best Cashback Credit Cards in Singapore 2024 - SingSaver', 'link': 'https://www.singsaver.com.sg/credit-card/cashback', 'snippet': 'Choose from the top cashback credit card options in Singapore for 2024, and enjoy money back on your everyday expenses.', 'attributes': {'Missing': 'households | Show results with:households'}, 'position': 3, 'selected': True}
2024-08-19 18:36:51 [2024-08-19 10:36:51,702: WARNING/ForkPoolWorker-7] Exploring data for report 16
2024-08-19 18:36:51 [2024-08-19 10:36:51,705: WARNING/ForkPoolWorker-7] Waiting for clarifications for report 16
2024-08-19 18:36:53 [2024-08-19 10:36:53,314: WARNING/ForkPoolWorker-7] Predicting for report 16
2024-08-19 18:36:55 [2024-08-19 10:36:55,192: WARNING/ForkPoolWorker-7] Optimizing for report 16
2024-08-19 18:36:55 [2024-08-19 10:36:55,779: WARNING/ForkPoolWorker-7] Exporting for report 16
2024-08-19 18:36:55 [2024-08-19 10:36:55,954: WARNING/ForkPoolWorker-7] Report 16 is done.
2024-08-19 18:36:55 [2024-08-19 10:36:55,958: WARNING/ForkPoolWorker-7] Completed celery task for bdbe4d376e6c8a53a791a86470b924c0715854bd353483523e3ab016eb55bcd0 in 4.50 seconds.
2024-08-19 18:36:55 [2024-08-19 10:36:55,963: INFO/ForkPoolWorker-7] Task oracle.core.begin_generation_task[026d4d09-4fac-4a1a-b5b8-ffd86d1c02eb] succeeded in 4.504813709998416s: None
```