### PR TITLE
Add dropdownRender to add buttons for "Select All" and "Remove All"

### DIFF
--- a/frontend/components/extract-metadata/MetadataTable.js
+++ b/frontend/components/extract-metadata/MetadataTable.js
@@ -303,10 +303,18 @@ const MetadataTable = ({
                 <div
                   style={{ padding: "8px", justifyContent: "space-between" }}
                 >
-                  <button type="button" className="mr-4" onClick={addAllTables}>
+                  <button
+                    type="button"
+                    className="mr-4 px-4 py-1 bg-gray-100 border border-gray-300 rounded-md shadow-sm hover:bg-gray-200 transition-colors duration-200"
+                    onClick={addAllTables}
+                  >
                     Add All ➕
                   </button>
-                  <button type="button" onClick={clearAllTables}>
+                  <button
+                    type="button"
+                    className="px-4 py-1 bg-gray-100 border border-gray-300 rounded-md shadow-sm hover:bg-gray-200 transition-colors duration-200"
+                    onClick={clearAllTables}
+                  >
                     Clear All ❌
                   </button>
                 </div>


### PR DESCRIPTION
We now have a dropdown option for automatically selecting and removing all tables from the db table select options

<img width="1301" alt="image" src="https://github.com/user-attachments/assets/bb13a2df-53b9-48ad-8411-4a0c082cff0e">

## What changed?
We make use of the `dropdownRender` prop that ChatGPT told me about!

## Known Issues
None