### PR TITLE
Delete partykit from dependencies of agents-python-server (tiny PR)

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -55,7 +55,6 @@ services:
       - agents-assets:/agents-assets/
       - ./backend:/backend
     depends_on:
-      - agents-partykit
       - agents-postgres
       - agents-redis
 


### PR DESCRIPTION
Seems like `agents-partykit` was not defined in services but listed in `depends_on` of `agents-python-server`!

Was getting this when I ran docker:

<img width="1163" alt="Screenshot 2024-08-22 at 10 37 04 AM" src="https://github.com/user-attachments/assets/4eeaafec-77e2-4e1e-8379-a0cd27f73278">

Now works!