### PR TITLE
Add task type

### DIFF
--- a/backend/db_utils.py
+++ b/backend/db_utils.py
@@ -56,8 +56,9 @@ Tools = Base.classes.defog_tools
 Users = Base.classes.defog_users
 Feedback = Base.classes.defog_plans_feedback
 DbCreds = Base.classes.defog_db_creds
-OracleReports = Base.classes.oracle_reports
+OracleSources = Base.classes.oracle_sources
 OracleClarifications = Base.classes.oracle_clarifications
+OracleReports = Base.classes.oracle_reports
 
 
 def save_csv_to_db(table_name, data):

--- a/backend/docker-setup-files/schema.sql
+++ b/backend/docker-setup-files/schema.sql
@@ -172,16 +172,17 @@ ALTER TABLE ONLY public.defog_tool_runs
 
 
 -- Oracle tables and data
-CREATE TABLE IF NOT EXISTS oracle_reports (
-    report_id SERIAL PRIMARY KEY,
-    report_name TEXT,
-    status TEXT,
-    created_ts TIMESTAMP,
-    api_key VARCHAR(255),
-    username TEXT,
-    inputs JSONB,
-    outputs JSONB,
-    feedback TEXT
+
+-- sources are not user or report specific and can be shared across multiple users/reports for now
+CREATE TABLE IF NOT EXISTS oracle_sources (
+    link TEXT PRIMARY KEY,
+    title TEXT,
+    position INT,
+    source_type TEXT,
+    attributes TEXT,
+    snippet TEXT,
+    text_parsed TEXT,
+    text_summary TEXT
 );
 
 CREATE TABLE IF NOT EXISTS oracle_clarifications (
@@ -192,4 +193,16 @@ CREATE TABLE IF NOT EXISTS oracle_clarifications (
     created_ts TIMESTAMP NOT NULL,
     resolved_ts TIMESTAMP,
     PRIMARY KEY (clarification_id, report_id)
+);
+
+CREATE TABLE IF NOT EXISTS oracle_reports (
+    report_id SERIAL PRIMARY KEY,
+    report_name TEXT,
+    status TEXT,
+    created_ts TIMESTAMP,
+    api_key VARCHAR(255),
+    username TEXT,
+    inputs JSONB,
+    outputs JSONB,
+    feedback TEXT
 );

--- a/backend/oracle/core.py
+++ b/backend/oracle/core.py
@@ -1,36 +1,51 @@
 import asyncio
+import json
+import os
 import random
 from asyncio import sleep
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
-from typing import Any, Dict
+from typing import Any, Dict, List
 
-from db_utils import OracleReports, engine
-from sqlalchemy import insert, select
+from db_utils import OracleReports, OracleSources, engine
+from generic_utils import make_request
+from sqlalchemy import insert, update, select
 from sqlalchemy.orm import Session
 
 from .celery_app import celery_app
 
+EXPLORATION = "exploration"
+PREDICTION = "prediction"
+OPTIMIZATION = "optimization"
+TASK_TYPES = [
+    EXPLORATION,
+    PREDICTION,
+    OPTIMIZATION,
+]
+DEFOG_BASE_URL = os.environ.get("DEFOG_BASE_URL", "https://api.defog.ai")
+
 celery_async_executors = ThreadPoolExecutor(max_workers=4)
+
 
 @celery_app.task
 def begin_generation_task(
-    api_key: str, username: str, report_id: int, inputs: Dict[str, Any]
+    api_key: str, username: str, report_id: int, task_type: str, inputs: Dict[str, Any]
 ):
     t_start = datetime.now()
     print(f"Starting celery task for {username} at {t_start}")
     with celery_async_executors:
         loop = asyncio.get_event_loop()
         task = loop.create_task(
-            begin_generation_async_task(api_key, username, report_id, inputs)
+            begin_generation_async_task(api_key, username, report_id, task_type, inputs)
         )
         loop.run_until_complete(task)
     t_end = datetime.now()
     time_elapsed = (t_end - t_start).total_seconds()
     print(f"Completed celery task for {username} in {time_elapsed:.2f} seconds.")
 
+
 async def begin_generation_async_task(
-    api_key: str, username: str, report_id: int, inputs: Dict[str, Any]
+    api_key: str, username: str, report_id: int, task_type: str, inputs: Dict[str, Any]
 ):
     """
     This is the entry point for the oracle, which will kick off the control flow,
@@ -52,6 +67,7 @@ async def begin_generation_async_task(
                 api_key=api_key,
                 username=username,
                 report_id=report_id,
+                task_type=task_type,
                 stage=stage,
                 inputs=inputs,
                 outputs=outputs,
@@ -70,7 +86,7 @@ async def begin_generation_async_task(
                 continue_generation = False
             else:
                 # get the next stage
-                stage = next_stage(stage)
+                stage = next_stage(stage, task_type)
         except Exception as e:
             # update the status of the report
             with Session(engine) as session:
@@ -82,16 +98,22 @@ async def begin_generation_async_task(
                 session.commit()
             continue_generation = False
 
-def next_stage(stage: str) -> str:
+
+def next_stage(stage: str, task_type: str) -> str:
     if stage == "gather_context":
-        return "explore"
-    elif stage == "explore":
         return "wait_clarifications"
     elif stage == "wait_clarifications":
-        return "predict"
-    elif stage == "predict":
-        return "optimize"
-    elif stage == "optimize":
+        return "explore"
+    elif stage == "explore":
+        if task_type == EXPLORATION:
+            return "export"
+        elif task_type == PREDICTION:
+            return "predict"
+        elif task_type == OPTIMIZATION:
+            return "optimize"
+    elif stage == "predict" and task_type == PREDICTION:
+        return "export"
+    elif stage == "optimize" and task_type == OPTIMIZATION:
         return "export"
     elif stage == "export":
         return "done"
@@ -103,6 +125,7 @@ async def execute_stage(
     api_key: str,
     username: str,
     report_id: str,
+    task_type: str,
     stage: str,
     inputs: Dict[str, Any],
     outputs: Dict[str, Any],
@@ -114,20 +137,58 @@ async def execute_stage(
     """
     if stage == "gather_context":
         stage_result = await gather_context(
-            api_key, username, report_id, inputs, outputs
+            api_key=api_key,
+            username=username,
+            report_id=report_id,
+            task_type=task_type,
+            inputs=inputs,
+            outputs=outputs,
         )
     elif stage == "explore":
-        stage_result = await explore_data(api_key, username, report_id, inputs, outputs)
+        stage_result = await explore_data(
+            api_key=api_key,
+            username=username,
+            report_id=report_id,
+            task_type=task_type,
+            inputs=inputs,
+            outputs=outputs,
+        )
     elif stage == "wait_clarifications":
         stage_result = await wait_clarifications(
-            api_key, username, report_id, inputs, outputs
+            api_key=api_key,
+            username=username,
+            report_id=report_id,
+            task_type=task_type,
+            inputs=inputs,
+            outputs=outputs,
         )
     elif stage == "predict":
-        stage_result = await predict(api_key, username, report_id, inputs, outputs)
+        stage_result = await predict(
+            api_key=api_key,
+            username=username,
+            report_id=report_id,
+            task_type=task_type,
+            inputs=inputs,
+            outputs=outputs,
+        )
     elif stage == "optimize":
-        stage_result = await optimize(api_key, username, report_id, inputs, outputs)
+        stage_result = await optimize(
+            api_key=api_key,
+            username=username,
+            report_id=report_id,
+            task_type=task_type,
+            inputs=inputs,
+            outputs=outputs,
+        )
     elif stage == "export":
-        stage_result = await export(api_key, username, report_id, inputs, outputs)
+        stage_result = await export(
+            api_key=api_key,
+            username=username,
+            report_id=report_id,
+            task_type=task_type,
+            inputs=inputs,
+            outputs=outputs,
+        )
     elif stage == "done":
         stage_result = None
         print(f"Report {report_id} is done.")
@@ -136,10 +197,12 @@ async def execute_stage(
         raise ValueError(f"Stage {stage} not recognized.")
     return stage_result
 
+
 async def gather_context(
     api_key: str,
     username: str,
     report_id: str,
+    task_type: str,
     inputs: Dict[str, Any],
     outputs: Dict[str, Any],
 ):
@@ -149,22 +212,68 @@ async def gather_context(
     which are relevant to the question and metric_sql provided.
     Side Effects:
     - Clarification questions generated at this stage will be saved to the
-        `clarifications` table in the SQLite3 database.
+        `oracle_clarifications` table.
     """
-    # TODO implement this function
-    # dummy print statement for now
     print(f"Gathering context for report {report_id}")
+    question = inputs["question"]
     print("Got the following sources:")
-    for source in inputs.get("sources", []):
+    sources = []
+    for source in inputs["sources"]:
+        if "link" in source:
+            source["type"] = "webpage"
+            sources.append(source)
         print(f"{source}")
-    # sleep for a random amount of time to simulate work
-    await sleep(random.random() * 2)
-    return {"context": "context gathered"}
+    json_data = {
+        "api_key": api_key,
+        "question": question,
+        "sources": sources,
+    }
+    # each source now contains "text" and "summary" keys
+    sources_parsed = await make_request(
+        DEFOG_BASE_URL + "/unstructured_data/parse", json_data
+    )
+    sources_to_insert = []
+    for source in sources_parsed:
+        attributes = source.get("attributes")
+        if isinstance(attributes, Dict) or isinstance(attributes, List):
+            attributes = json.dumps(attributes)
+        source_to_insert = {
+            "link": source["link"],
+            "title": source.get("title", ""),
+            "position": source.get("position"),
+            "source_type": source.get("type"),
+            "attributes": attributes,
+            "snippet": source.get("snippet"),
+            "text_parsed": source.get("text"),
+            "text_summary": source.get("summary"),
+        }
+        sources_to_insert.append(source_to_insert)
+    with Session(engine) as session:
+        # insert the sources into the database if not present. otherwise update
+        for source in sources_to_insert:
+            stmt = select(OracleSources).where(OracleSources.link == source["link"])
+            result = session.execute(stmt)
+            if result.scalar() is None:
+                stmt = insert(OracleSources).values(source)
+                session.execute(stmt)
+            else:
+                stmt = (
+                    update(OracleSources)
+                    .where(OracleSources.link == source["link"])
+                    .values(source)
+                )
+                session.execute(stmt)
+            print(f"Inserted source {source['link']} into the database.")
+        session.commit()
+    # TODO summarize all sources, attempt formulation and save clarification questions into DB
+    return {"sources": sources_parsed}
+
 
 async def explore_data(
     api_key: str,
     username: str,
     report_id: str,
+    task_type: str,
     inputs: Dict[str, Any],
     outputs: Dict[str, Any],
 ):
@@ -173,16 +282,17 @@ async def explore_data(
     data analysis (EDA) plots and tables, which are relevant to the data provided.
     Side Effects:
     - Intermediate data and plots will be saved in the report_id's directory.
-    - Clarification questions will be saved to the `clarifications` table.
     """
     # TODO implement this function
     # dummy print statement for now
     print(f"Exploring data for report {report_id}")
 
+
 async def wait_clarifications(
     api_key: str,
     username: str,
     report_id: str,
+    task_type: str,
     inputs: Dict[str, Any],
     outputs: Dict[str, Any],
 ):
@@ -198,10 +308,12 @@ async def wait_clarifications(
     await sleep(random.random() * 2)
     return {"clarifications": "all clarifications addressed"}
 
+
 async def predict(
     api_key: str,
     username: str,
     report_id: str,
+    task_type: str,
     inputs: Dict[str, Any],
     outputs: Dict[str, Any],
 ):
@@ -218,10 +330,12 @@ async def predict(
     await sleep(random.random() * 2)
     return {"predictions": "predictions generated"}
 
+
 async def optimize(
     api_key: str,
     username: str,
     report_id: str,
+    task_type: str,
     inputs: Dict[str, Any],
     outputs: Dict[str, Any],
 ):
@@ -238,10 +352,12 @@ async def optimize(
     await sleep(random.random() * 2)
     return {"optimization": "optimization completed"}
 
+
 async def export(
     api_key: str,
     username: str,
     report_id: str,
+    task_type: str,
     inputs: Dict[str, Any],
     outputs: Dict[str, Any],
 ):

--- a/frontend/components/oracle/TaskType.js
+++ b/frontend/components/oracle/TaskType.js
@@ -1,0 +1,43 @@
+import {
+  SearchOutlined,
+  LineChartOutlined,
+  ThunderboltOutlined,
+} from "@ant-design/icons";
+import { Tag } from "antd";
+
+export default function TaskType({ taskType }) {
+  if (taskType === "exploration") {
+    return (
+      <div className="flex items-center my-2">
+        <h4 className="text-l font-semibold pr-4">Task Type</h4>
+        <div className="inline-flex items-center w-max h-10 gap-2.5 border border-gray-300 rounded-md">
+          <SearchOutlined className="text-[#1B1B16]/30 ml-2" />
+          <h6 className="mr-2">Exploration</h6>
+        </div>
+      </div>
+    );
+  }
+  if (taskType === "prediction") {
+    return (
+      <div className="flex items-center my-2">
+        <h4 className="text-l font-semibold pr-4">Task Type</h4>
+        <div className="inline-flex items-center w-max h-10 gap-2.5 border border-gray-300 rounded-md">
+          <LineChartOutlined className="text-[#1B1B16]/30 ml-2" />
+          <h6 className="mr-2">Prediction</h6>
+        </div>
+      </div>
+    );
+  }
+  if (taskType === "optimization") {
+    return (
+      <div className="flex items-center my-2">
+        <h4 className="text-l font-semibold pr-4">Task Type</h4>
+        <div className="inline-flex items-center w-max h-10 gap-2.5 border border-gray-300 rounded-md">
+          <ThunderboltOutlined className="text-[#1B1B16]/30 ml-2" />
+          <h6 className="mr-2">Optimization</h6>
+        </div>
+      </div>
+    );
+  }
+  return null;
+}

--- a/frontend/pages/oracle-frontend.js
+++ b/frontend/pages/oracle-frontend.js
@@ -3,6 +3,7 @@ import { useState, useEffect } from "react";
 import Meta from "$components/layout/Meta";
 import Scaffolding from "$components/layout/Scaffolding";
 import Sources from "$components/oracle/Sources";
+import TaskType from "$components/oracle/TaskType";
 import setupBaseUrl from "$utils/setupBaseUrl";
 import {
   CheckCircleOutlined,
@@ -44,6 +45,7 @@ function OracleDashboard() {
   const [userTask, setUserTask] = useState("");
   const [clarifications, setClarifications] = useState([]);
   const [waitClarifications, setWaitClarifications] = useState(false);
+  const [taskType, setTaskType] = useState("");
   const [sources, setSources] = useState([]);
   const [waitSources, setWaitSources] = useState(false);
   const [ready, setReady] = useState(false);
@@ -52,26 +54,25 @@ function OracleDashboard() {
   const getClarifications = async () => {
     setWaitClarifications(true);
     const token = localStorage.getItem("defogToken");
-    const res = await fetch(
-      setupBaseUrl("http", `oracle/clarify_formulation`),
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          token: token,
-          key_name: apiKeyName,
-          question: userTask,
-        }),
-      }
-    );
+    const res = await fetch(setupBaseUrl("http", `oracle/clarify_question`), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        token: token,
+        key_name: apiKeyName,
+        question: userTask,
+      }),
+    });
     setWaitClarifications(false);
     if (res.ok) {
       const data = await res.json();
       // we have the following fields to set:
       // - data.clarifications [list of string]
+      // - data.task_type [string]
       // - data.ready [bool]
+      setTaskType(data.task_type);
       setClarifications(data.clarifications);
       setReady(data.ready);
     } else {
@@ -201,6 +202,7 @@ function OracleDashboard() {
         key_name: apiKeyName,
         question: userTask,
         sources: selectedSources,
+        task_type: taskType,
       }),
     });
 
@@ -295,10 +297,11 @@ function OracleDashboard() {
             // show clarifications only when there are some
             <div className="mt-6">
               <h2 className="text-xl font-semibold mb-2">Clarifications</h2>
+              <TaskType taskType={taskType} />
               {clarifications.map((clarification, index) => (
                 <div
                   key={index}
-                  className="bg-amber-100 p-4 rounded-lg mb-4 relative"
+                  className="bg-amber-100 p-4 rounded-lg my-2 relative"
                 >
                   <p className="text-amber-500">{clarification}</p>
                   <CloseOutlined
@@ -315,7 +318,7 @@ function OracleDashboard() {
           </div>
 
           <Button
-            className="bg-purple-500 text-white py-2 px-4 rounded-lg hover:bg-purple-600"
+            className="bg-purple-500 text-white py-4 px-4 mt-2 mb-2 rounded-lg hover:bg-purple-600"
             onClick={generateReport}
           >
             Generate


### PR DESCRIPTION
# Changes
- Add task type on the frontend as part of the clarifications for visual confirmation for the user. see [loom link](https://www.loom.com/share/730e50c9515a4a2bb26c67306ec7da96?sid=18dd424e-0843-475d-b7ce-9fc7842b0111) for how that looks like.
- Update `/oracle/clarify_formulation` to `/oracle/clarify_question` and use the 2-step requests to get the task type first and then clarify for the given task type. Front-end page routes updated as well to reflect the updated semantics.
- Pass `task_type` through to oracle core. This is to allow us to reconfigure the `next_step` function to select the next stage depending on the task type as well. For `exploration`, we can terminate earlier and don't need later stages (e.g. `prediction`, `optimization`). Note that `optimization` no longer depends on `prediction` in this update, but only on `exploration`. We also shift `wait_clarifications` to before `explore`, since `explore` would be the last and only data processing stage for the `exploration` task type.
- more input validation for `/begin_generation`
- add `oracle_sources` table

# Testing
To test this out, besides checking out the branch locally, you would need to add the new table to your defog-self-hosted's postgres container (assuming you don't want to nuke your existing data). You can click on the `exec` tab and run `psql -U postgres`, then paste the following DDL to initialize the new table:
```sql
CREATE TABLE IF NOT EXISTS oracle_sources (
    link TEXT PRIMARY KEY,
    title TEXT,
    position INT,
    source_type TEXT,
    attributes TEXT,
    snippet TEXT,
    text_parsed TEXT,
    text_summary TEXT
);
```
Once done, you can do the usual `docker compose up`, then `npm run dev` in the `frontend` folder, then navigate to http://localhost:1236/oracle-frontend to see the updated page.

You should notice 2 changes:
- on the frontend, there should be the task type showing up on the UI
- in the agents-python-server's logs, you should see more logs showing the new routing logic as well as DB insertion logs during the `gather_context` stage (also demonstrated in the loom demo).