### PR TITLE
Oracle Reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ oracle/reports
 # golden queries
 backend/golden_queries.csv
 backend/bq.json
+
+# oracle reports
+backend/oracle/reports

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,17 +1,13 @@
 import logging
 import os
-import trace
 import traceback
-from fastapi import FastAPI, WebSocket, Request
+from fastapi import FastAPI, Request
 from fastapi.responses import FileResponse
-from starlette.websockets import WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from connection_manager import ConnectionManager
-from agents.planner_executor.execute_tool import execute_tool
 from agents.planner_executor.planner_executor_agent_rest import RESTExecutor
 from oracle.setup import setup_dir
 import doc_endpoints
-from uuid import uuid4
 from utils import make_request
 
 from db_utils import (

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -10,6 +10,7 @@ google-cloud-bigquery
 google-cloud-storage
 httpx
 hypercorn
+markdown-pdf
 matplotlib
 mysql-connector-python
 numpy


### PR DESCRIPTION
# Changes
- add download endpoint which returns a FileResponse that sends the exported pdf over
- implement export stage, where we make a request with all of our inputs/outputs to defog-backend-python for the markdown generation. upon receipt of the report's markdown, we use `markdown-pdf` to convert the markdown to pdf, and save it in the local file directory. the markdown is saved in the postgres database as part of the usual post-stage update.
- update UI
  - download the pdf when the user clicks on the Download button
  - update download and delete buttons with icons
  - disable download/deletions when reports are still processing / not done.
  - disable downloading if the report generation resulted in an error.

# Testing
Check out this loom video for a quick run through of the functional changes and a brief walkthrough of the updated file structure:
https://www.loom.com/share/a23a2455ad7f4f3782d298cb0004cbcc?sid=34c59d5a-fd53-4a71-8248-3d91d7e57f35