### PR TITLE
add chart editing route

### DIFF
--- a/backend/utils_logging.py
+++ b/backend/utils_logging.py
@@ -4,7 +4,10 @@ import os
 import time
 from typing import List, Tuple
 
-LOG_LEVEL = os.getenv('LOG_LEVEL', 'INFO').upper()  # Ensure uppercase for consistency
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()  # Ensure uppercase for consistency
+if LOG_LEVEL == "":
+    LOG_LEVEL = "INFO"
+
 print(f"Setting log level to {LOG_LEVEL}")
 
 LOG_CONFIG = {
@@ -40,6 +43,7 @@ dictConfig(LOG_CONFIG)
 # This is the global logger object that we'll use throughout the server
 LOGGER = logging.getLogger("server")
 
+
 def save_timing(t_start: float, msg: str, timings: List[Tuple[float, str]]) -> float:
     """
     Saves the current duration since t_start along with the message msg into the timings list.
@@ -50,6 +54,7 @@ def save_timing(t_start: float, msg: str, timings: List[Tuple[float, str]]) -> f
     timings.append((t_end - t_start, msg))
     return t_end
 
+
 def log_timings(timings: List[Tuple[float, str]]) -> None:
     """
     Prints out the timings in the timings list.
@@ -57,6 +62,7 @@ def log_timings(timings: List[Tuple[float, str]]) -> None:
     """
     for timing, msg in timings:
         LOGGER.info(f"{timing:.2f}s: {msg}")
+
 
 def save_and_log(t_start: float, msg: str, timings: List[Tuple[float, str]]) -> float:
     """


### PR DESCRIPTION
Adds a chart editing route which takes in a user question, a chart state and some information about the dataframe's columns, and returns the edits to the chart state.

You will need to pull https://github.com/defog-ai/agents-ui-components/pull/31 and https://github.com/defog-ai/defog-backend-python/pull/186 to test this.

This is best tested from the UI, but to test from your terminal:

First pull the above branches, and run: `docker compose up` for both `self-hosted` and `backend-python`.

Then from your terminal do:
```bash
curl -X POST 'http://localhost/edit_chart' \
-d '{
  "user_request": "change the line colour to red",
  "current_chart_state": {
    "selectedChart": "line",
    "selectedColumns": {"x": "rating", "y": "year"},
    "chartStyle": {"stroke": "black"}
  },
  "columns": [
    {"title": "rid","col_type": "integer"},
    {"title": "business_id","col_type": "string"},
    {"title": "user_id","col_type": "string"},
    {"title": "rating","col_type": "decimal"},
    {"title": "text","col_type": "string"},
    {"title": "year","col_type": "date"},
    {"title": "month","col_type": "date"},
    {"title": "index","col_type": "integer"}
  ]
}'
```

And you should get:
```json
{"success":true,"chart_state_edits":{"chartStyle":{"stroke":"red"}}}
```


To test some error modes, try:
```bash
curl -X POST 'http://localhost/edit_chart' \
-d '{
  "user_request": "change the line colour to red",
   "columns": [{"title": "year", "col_type": "string"}]
}'
```

You should get:
```json
{"success":false,"error_message":"Invalid chart state provided."}
```

```bash
curl -X POST 'http://localhost/edit_chart' \
-d '{
   "columns": [{"title": "year", "col_type": "string"}]
}'
```

Response:
```json
{"success":false,"error_message":"Invalid user request provided."}
```


UI testing instructions are in the `agents-ui` [PR](https://github.com/defog-ai/agents-ui-components/pull/31)