### PR TITLE
use slimmer postgres alpine image

### DIFF
--- a/dockerfile.agents-postgres
+++ b/dockerfile.agents-postgres
@@ -1,1 +1,1 @@
-FROM postgres:latest
+FROM postgres:16-alpine


### PR DESCRIPTION
Updated postgres docker image to use the slimmer alpine image (252MB) instead of the default that installs a full OS in the image (450MB+).
Tested with a normal request and it works:
```
curl --location '0.0.0.0:80/integration/get_metadata' \
--header 'Content-Type: application/json' \
--data '{
    "key_name": "Dataset 1",
    "token": "bdbe4d376e6c8a53a791a86470b924c0715854bd353483523e3ab016eb55bcd0"
}'
```
Could also still run `psql -U postgres` with docker exec