### PR TITLE
bugfixes with instructions update and check readiness page

### DIFF
--- a/backend/integration_routes.py
+++ b/backend/integration_routes.py
@@ -486,6 +486,7 @@ async def update_glossary(request: Request):
             dev=dev,
         )
     else:
+        dev = params.get("dev", False)
         # first, get the existing glossary
         url = DEFOG_BASE_URL + "/get_glossary"
         resp = await make_request(url, {"api_key": api_key, "dev": dev})
@@ -502,7 +503,6 @@ async def update_glossary(request: Request):
         if new_instructions:
             glossary_prunable_units += new_instructions.split("\n")
 
-        dev = params.get("dev", False)
 
         defog = Defog(api_key=api_key, db_type=db_type, db_creds=db_creds)
         defog.base_url = DEFOG_BASE_URL

--- a/backend/readiness_routes.py
+++ b/backend/readiness_routes.py
@@ -14,7 +14,7 @@ router = APIRouter()
 async def check_basic_readiness(request: Request):
     params = await request.json()
     token = params.get("token")
-    dev = params.get("dev")
+    dev = params.get("dev", False)
     if not validate_user(token, user_type="admin"):
         return JSONResponse(
             status_code=401,
@@ -59,7 +59,7 @@ async def check_basic_readiness(request: Request):
 async def check_golden_queries_validity(request: Request):
     params = await request.json()
     token = params.get("token")
-    dev = params.get("dev")
+    dev = params.get("dev", False)
     if not validate_user(token, user_type="admin"):
         return JSONResponse(
             status_code=401,


### PR DESCRIPTION
`dev` was not declared before use and that caused error on two instances:

1) visiting  check readiness page on the frontend lead to this:

![Screenshot 2024-09-10 at 9 12 03 PM](https://github.com/user-attachments/assets/83fcb41d-17e9-4305-8873-a6165edcc990)

2) update glossary from the recommendations modal lead to an update in optional instructions update which was using dev before assigning a value to it.

```

agents-python-server-1  |     return await dependant.call(**values)
agents-python-server-1  |   File "/backend/integration_routes.py", line 491, in update_glossary
agents-python-server-1  |     resp = await make_request(url, {"api_key": api_key, "dev": dev})
agents-python-server-1  | UnboundLocalError: local variable 'dev' referenced before assignment
```