### PR TITLE
Ensure text areas are resizable and changed "glossary" to "instructions"

### DIFF
--- a/frontend/components/align-model/Instructions.js
+++ b/frontend/components/align-model/Instructions.js
@@ -23,27 +23,27 @@ const Instructions = ({
           : "Loading Instructions"
       }
     >
-      <h3 className="text-lg font-semibold">Compulsory Glossary</h3>
+      <h3 className="text-lg font-semibold">Compulsory Instructions</h3>
       <p className="text-sm text-gray-700 mb-2">
         These are the instructions that the model is given for every single SQL
         query that it generates.
       </p>
       <textarea
-        className="w-full h-40 p-2 border rounded border-gray-300 shadow-sm focus:border-gray-500 focus:ring focus:ring-gray-200 transition duration italic"
+        className="w-full min-h-40 p-2 border rounded border-gray-300 shadow-sm focus:border-gray-500 focus:ring focus:ring-gray-200 transition duration italic resize-y"
         value={compulsoryGlossary}
         onChange={(e) => setCompulsoryGlossary(e.target.value)}
         rows={8}
         disabled={isLoading}
       />
-
-      <h3 className="text-lg font-semibold mt-4">Prunable Glossary</h3>
+      
+      <h3 className="text-lg font-semibold mt-4">Supplementary Instructions</h3>
       <p className="text-sm text-gray-700 mb-2">
         These are the instructions that are specific to only specific kinds of
         questions.
       </p>
 
       <textarea
-        className="w-full h-40 p-2 border rounded border-gray-300 shadow-sm focus:border-gray-500 focus:ring focus:ring-gray-200 transition duration italic"
+        className="w-full min-h-40 p-2 border rounded border-gray-300 shadow-sm focus:border-gray-500 focus:ring focus:ring-gray-200 transition duration italic resize-y"
         value={prunableGlossary}
         onChange={(e) => setPrunableGlossary(e.target.value)}
         rows={8}

--- a/frontend/pages/align-model.js
+++ b/frontend/pages/align-model.js
@@ -235,7 +235,7 @@ const AlignModel = () => {
             />
           ) : null} */}
           <Instructions
-            title="Glossary"
+            title="Instructions"
             description="This the information about your data that the model considers when generating your SQL queries. Feel free to edit these instructions to get the best results."
             compulsoryGlossary={compulsoryGlossary}
             setCompulsoryGlossary={setCompulsoryGlossary}


### PR DESCRIPTION
Addresses this issue: https://linear.app/defog/issue/DEF-517/ensure-that-text-areas-are-resizeable
Can dynamically resize the tex areas here (vertically) now:
<img width="1342" alt="Screenshot 2024-09-12 at 1 38 56 AM" src="https://github.com/user-attachments/assets/ea3afa75-de88-4ebe-b682-63dba6c3dc85">
<img width="1342" alt="Screenshot 2024-09-12 at 1 39 10 AM" src="https://github.com/user-attachments/assets/06d790ab-727d-4a05-961a-14b68a8f607d">
