### PR TITLE
Unify make request

### DIFF
--- a/backend/agent_routes.py
+++ b/backend/agent_routes.py
@@ -205,7 +205,7 @@ async def generate_step(request: Request):
                     )
                     unified_question = await make_request(
                         url=question_unifier_url,
-                        json={
+                        data={
                             "api_key": api_key,
                             "question": question,
                             "previous_context": prev_questions,
@@ -569,7 +569,7 @@ async def edit_chart(request: Request):
 
         res = await make_request(
             url=edit_chart_url,
-            json={
+            data={
                 "user_request": user_request,
                 "columns": [
                     {"title": c["title"], "col_type": c["col_type"]} for c in columns

--- a/backend/agents/clarifier/clarifier_agent.py
+++ b/backend/agents/clarifier/clarifier_agent.py
@@ -7,7 +7,7 @@ import asyncio
 import requests
 import os
 
-from utils import make_request
+from generic_utils import make_request
 
 default_values_formatted = {
     "multi select": [],
@@ -38,7 +38,7 @@ async def turn_into_statements(clarification_questions, dfg_api_key):
         ],
         "api_key": dfg_api_key,
     }
-    r = await make_request(url, payload=payload)
+    r = await make_request(url, data=payload)
     statements = r.json()["statements"]
     return statements
 
@@ -78,7 +78,7 @@ async def get_clarification(question, api_key, dev=False, temp=False):
 
     r = await make_request(
         llm_calls_url,
-        payload=payload,
+        data=payload,
     )
 
     if r.status_code == 200:

--- a/backend/agents/planner_executor/planner_executor_agent_rest.py
+++ b/backend/agents/planner_executor/planner_executor_agent_rest.py
@@ -90,7 +90,7 @@ class RESTExecutor:
                 "llm_server_url": os.environ.get("LLM_SERVER_ENDPOINT", None),
                 "model_name": os.environ.get("LLM_MODEL_NAME", None),
             }
-            ans = await make_request(llm_calls_url, json=payload)
+            ans = await make_request(llm_calls_url, data=payload)
 
             ans = ans["generated_step"]
             self.previous_responses.append(ans)

--- a/backend/db_utils.py
+++ b/backend/db_utils.py
@@ -18,10 +18,10 @@ from sqlalchemy import (
 from sqlalchemy.schema import DropTable
 from sqlalchemy.ext.automap import automap_base
 from utils_logging import LOGGER
-from utils_md import mk_create_table_ddl
 
 import asyncio
-from utils import warn_str, YieldList, make_request
+from utils import warn_str, YieldList
+from generic_utils import make_request
 import os
 
 analysis_assets_dir = os.environ.get(
@@ -1545,7 +1545,7 @@ async def add_tool(
         asyncio.create_task(
             make_request(
                 url=f"{os.environ.get('DEFOG_BASE_URL', 'https://api.defog.ai')}/update_tool",
-                payload={
+                data={
                     "api_key": api_key,
                     "tool_name": tool_name,
                     "function_name": function_name,
@@ -1559,7 +1559,6 @@ async def add_tool(
                     "cannot_delete": cannot_delete,
                     "cannot_disable": cannot_disable,
                 },
-                verbose=True,
             )
         )
     except ValueError as e:

--- a/backend/feedback_routes.py
+++ b/backend/feedback_routes.py
@@ -73,7 +73,7 @@ async def get_feedback(request: Request):
     key_name = params.get("key_name")
     api_key = get_api_key_from_key_name(key_name)
     url = DEFOG_BASE_URL + "/get_feedback"
-    res = await make_request(url, json={"api_key": api_key})
+    res = await make_request(url, data={"api_key": api_key})
     data = res["data"]
     for idx, item in enumerate(data):
         # first item is created_at
@@ -131,7 +131,7 @@ async def get_instructions_recommendation(request: Request):
 
     r = await make_request(
         url=url,
-        json={
+        data={
             "api_key": api_key,
             "question": question,
             "sql_generated": sql_generated,
@@ -165,5 +165,5 @@ async def send_feedback(params_obj):
 
     """
     url = DEFOG_BASE_URL + "/feedback"
-    res = await make_request(url, json=params_obj)
+    res = await make_request(url, data=params_obj)
     return res

--- a/backend/imgo_routes.py
+++ b/backend/imgo_routes.py
@@ -1,3 +1,4 @@
+
 from fastapi import APIRouter, Request
 from generic_utils import (
     make_request,
@@ -44,7 +45,7 @@ async def send_imgo_request(
         payload.update(additional_payload)
 
     url = f"{DEFOG_BASE_URL}/{endpoint}"
-    return await make_request(url, json=payload)
+    return await make_request(url, data=payload)
 
 
 @router.post("/generate_golden_queries_from_questions")
@@ -120,5 +121,5 @@ async def check_task_status(request: Request):
     url = f"{DEFOG_BASE_URL}/check_imgo_task_status"
     return await make_request(
         url,
-        json={"api_key": api_key, "task_id": task_id},
+        data={"api_key": api_key, "task_id": task_id},
     )

--- a/backend/integration_routes.py
+++ b/backend/integration_routes.py
@@ -341,7 +341,7 @@ async def update_metadata(request: Request):
     # update on API server
     r = await make_request(
         DEFOG_BASE_URL + "/update_metadata",
-        json={
+        data={
             "api_key": api_key,
             "table_metadata": table_metadata,
             "db_type": db_type,
@@ -368,7 +368,7 @@ async def copy_prod_to_dev(request: Request):
     api_key = get_api_key_from_key_name(key_name)
 
     r = await make_request(
-        DEFOG_BASE_URL + "/copy_prod_to_dev", json={"api_key": api_key}
+        DEFOG_BASE_URL + "/copy_prod_to_dev", data={"api_key": api_key}
     )
 
     return r
@@ -390,7 +390,7 @@ async def copy_prod_to_dev(request: Request):
     api_key = get_api_key_from_key_name(key_name)
 
     r = await make_request(
-        DEFOG_BASE_URL + "/copy_dev_to_prod", json={"api_key": api_key}
+        DEFOG_BASE_URL + "/copy_dev_to_prod", data={"api_key": api_key}
     )
 
     return r
@@ -625,7 +625,7 @@ async def upload_csv(request: Request):
 
     resp = await make_request(
         DEFOG_BASE_URL + "/update_metadata",
-        json={
+        data={
             "api_key": api_key,
             "table_metadata": schema,
             "db_type": db_type,

--- a/backend/main.py
+++ b/backend/main.py
@@ -8,14 +8,13 @@ from connection_manager import ConnectionManager
 from agents.planner_executor.planner_executor_agent_rest import RESTExecutor
 from oracle.setup import setup_dir
 import doc_endpoints
-from utils import make_request
 
 from db_utils import (
     get_all_analyses,
     get_analysis_data,
     initialise_analysis,
 )
-from generic_utils import get_api_key_from_key_name
+from generic_utils import get_api_key_from_key_name, make_request
 import integration_routes, query_routes, admin_routes, auth_routes, readiness_routes, csv_routes, feedback_routes, slack_routes, agent_routes, oracle_routes, imgo_routes, data_connector_routes
 
 logging.basicConfig(level=logging.INFO)
@@ -73,7 +72,7 @@ edit_request_types_and_prop_names = {
 async def get_classification(question, api_key, debug=False):
     r = await make_request(
         f"{os.environ.get('DEFOG_BASE_URL', 'https://api.defog.ai')}/update_agent_feedback",
-        payload={"question": question, "api_key": api_key},
+        data={"question": question, "api_key": api_key},
     )
     if r.status_code == 200:
         return r.json()

--- a/backend/oracle/core.py
+++ b/backend/oracle/core.py
@@ -488,7 +488,7 @@ async def explore_data(
     problem_statement = gather_context.get("problem_statement", "")
     glossary_dict = await make_request(
         DEFOG_BASE_URL + "/prune_glossary",
-        json={"question": user_question, "api_key": api_key},
+        data={"question": user_question, "api_key": api_key},
     )
     glossary = f"{glossary_dict.get('glossary_compulsory', '')}\n{glossary_dict.get('glossary', '')}\n{context}"
     db_type, db_creds = get_db_type_creds(api_key)
@@ -670,7 +670,7 @@ async def explore_data(
                 "final_summaries_str": final_summaries_str,
             }
             resp = await make_request(
-                f"{DEFOG_BASE_URL}/oracle/eval_explorer_data_analysis", json=json_data
+                f"{DEFOG_BASE_URL}/oracle/eval_explorer_data_analysis", data=json_data
             )
             if "error" in resp:
                 LOGGER.error(f"Error occurred in evaluating analysis: {resp['error']}")

--- a/backend/oracle/utils_explore_data.py
+++ b/backend/oracle/utils_explore_data.py
@@ -26,7 +26,7 @@ async def gen_sql(api_key: str, db_type: str, question: str, glossary: str) -> s
     """
     resp = await make_request(
         f"{DEFOG_BASE_URL}/generate_query_chat",
-        json={
+        data={
             "api_key": api_key,
             "dev": False,
             "db_type": db_type,
@@ -101,7 +101,7 @@ async def get_chart_type(api_key: str, columns: list, question: str) -> str:
     }
     resp = await make_request(
         f"{DEFOG_BASE_URL}/get_chart_type",
-        json=json_data,
+        data=json_data,
     )
     if "chart_type" in resp:
         return resp
@@ -218,7 +218,7 @@ async def gen_data_analysis(
         "sampled": sampled,
     }
     resp = await make_request(
-        f"{DEFOG_BASE_URL}/oracle/gen_explorer_data_analysis", json=json_data
+        f"{DEFOG_BASE_URL}/oracle/gen_explorer_data_analysis", data=json_data
     )
     if "error" in resp:
         LOGGER.error(f"Error occurred in generating data analysis: {resp['error']}")

--- a/backend/query_routes.py
+++ b/backend/query_routes.py
@@ -87,6 +87,6 @@ async def get_chart_types(request: Request):
 
     res = await make_request(
         "https://api.defog.ai/get_chart_type",
-        json={"api_key": api_key, "columns": columns, "question": question},
+        data={"api_key": api_key, "columns": columns, "question": question},
     )
     return res

--- a/backend/readiness_routes.py
+++ b/backend/readiness_routes.py
@@ -79,7 +79,7 @@ async def check_golden_queries_validity(request: Request):
 
     resp = await make_request(
         f"{DEFOG_BASE_URL}/check_gold_queries_valid",
-        json={"api_key": api_key, "db_type": db_type, "dev": dev},
+        data={"api_key": api_key, "db_type": db_type, "dev": dev},
     )
     return resp
 
@@ -103,7 +103,7 @@ async def check_glossary_consistency(request: Request):
 
     resp = await make_request(
         f"{DEFOG_BASE_URL}/check_glossary_consistency",
-        json={"api_key": api_key, "dev": dev},
+        data={"api_key": api_key, "dev": dev},
     )
     return resp
 
@@ -132,6 +132,6 @@ async def check_golden_query_coverage(request: Request):
 
     resp = await make_request(
         f"{DEFOG_BASE_URL}/get_golden_queries_coverage",
-        json={"api_key": api_key, "dev": dev, "db_type": db_type},
+        data={"api_key": api_key, "dev": dev, "db_type": db_type},
     )
     return resp

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -149,19 +149,6 @@ class SqlExecutionError(Exception):
         # Now for your custom code...
         self.sql = sql
 
-
-async def make_request(url, payload, verbose=False):
-    print(f"Making request to {url}")
-    async with httpx.AsyncClient(verify=False) as client:
-        r = await client.post(
-            url,
-            json=payload,
-        )
-        if verbose:
-            print(f"Response: {r.text}")
-    return r
-
-
 def deduplicate_columns(df: pd.DataFrame):
     # de-duplicate column names
     # if the same column name exists more than once, add a suffix


### PR DESCRIPTION
- Remove duplicate `make_request` function in `utils`
- Rename parameter name json to data to avoid potential name conflict with imported `json` module (i.e. `json.loads(json)` is an accident waiting to happen)
- Print out only first n chars of the json data to avoid flooding logs (esp when there is chart data)

Tested out by going to a bunch of different parts of the UI and verified that the routes still work.