### PR TITLE
Fix defog_users inconsistencies

### DIFF
--- a/backend/admin_routes.py
+++ b/backend/admin_routes.py
@@ -105,7 +105,6 @@ async def add_user(request: Request):
                         token=INTERNAL_API_KEY,
                         user_type=dets["user_type"],
                         allowed_dbs=dets["allowed_dbs"],
-                        is_premium=True,
                     )
                 )
 

--- a/backend/create_admin_user.py
+++ b/backend/create_admin_user.py
@@ -1,9 +1,7 @@
-import time
+import hashlib
 
 from db_utils import engine, Users
 from sqlalchemy import select, insert
-import hashlib
-import time
 
 SALT = "TOMMARVOLORIDDLE"
 INTERNAL_API_KEY = "dummy_api_key"
@@ -30,7 +28,6 @@ else:
                 hashed_password=hashed_password,
                 token=INTERNAL_API_KEY,
                 user_type="admin",
-                is_premium=True,
             )
         )
     print("Admin user created.")

--- a/backend/db_utils.py
+++ b/backend/db_utils.py
@@ -1,5 +1,4 @@
 import inspect
-import json
 import logging
 import traceback
 import datetime
@@ -261,7 +260,7 @@ def save_csv_to_db(
         )
         return True
     except Exception as e:
-        print(e)
+        LOGGER.error(e)
         return False
 
 
@@ -271,7 +270,7 @@ def get_db_type_creds(api_key):
             select(DbCreds.db_type, DbCreds.db_creds).where(DbCreds.api_key == api_key)
         ).fetchone()
 
-    print(row)
+    LOGGER.debug(row)
 
     return row
 

--- a/backend/docker-setup-files/schema.sql
+++ b/backend/docker-setup-files/schema.sql
@@ -106,10 +106,8 @@ CREATE TABLE public.defog_users (
     hashed_password text,
     token text NOT NULL,
     user_type text NOT NULL,
-    csv_tables text,
-    is_premium boolean,
     created_at timestamp without time zone,
-    is_verified boolean
+    allowed_dbs text
 );
 
 ALTER TABLE public.defog_users OWNER TO postgres;


### PR DESCRIPTION
Fix inconsistencies in DB schema with explicit schema defined in [create_sql_tables.py](https://github.com/defog-ai/defog-self-hosted/blob/c105b61dbee5e979c21d2016ea4befa6be8dfaf3/backend/create_sql_tables.py#L115-L124). We resolve all differences with the table definitions in `create_sql_tables.py`, since the class/schema definitions are enforced during startup. Specifically,
- remove `is_premium` value assignments/filters
- remove `csv_tables` and `is_verified` since these aren't useful for defog-self-hosted and are not defined in `create_sql_tables.py`
- add `allowed_dbs` into `schema.sql` for future "clean-slate" users to have this column right from the start. this new column is manually added in `create_sql_tables.py` currently.

Tested with a rebuild of the code, and polling some of the admin routes:
```
curl --location '0.0.0.0:80/admin/get_users' \
--header 'Content-Type: application/json' \
--data '{
    "token": "bdbe4d376e6c8a53a791a86470b924c0715854bd353483523e3ab016eb55bcd0"
}'
```
```json
{
    "users": [
        {
            "username": "admin",
            "user_type": "admin",
            "allowed_dbs": null
        }
    ]
}
```

To verify backwards compatibility, I manually added the `is_premium` column to the `defog_users` table and restarted the `agents-python-server`, and the logs indicate `defog_users` still map ok. admin routes also test fine after the manual addition.
psql logs:
```
postgres=# SELECT * FROM defog_users;
 username |                         hashed_password                          |     token     | user_type | created_at | allowed_dbs 
----------+------------------------------------------------------------------+---------------+-----------+------------+-------------
 admin    | bdbe4d376e6c8a53a791a86470b924c0715854bd353483523e3ab016eb55bcd0 | dummy_api_key | admin     |            | 
(1 row)
postgres=# ALTER TABLE defog_users
postgres-# ADD COLUMN is_premium BOOLEAN DEFAULT FALSE;
ALTER TABLE
postgres=# SELECT * FROM defog_users;
 username |                         hashed_password                          |     token     | user_type | created_at | allowed_dbs | is_premium 
----------+------------------------------------------------------------------+---------------+-----------+------------+-------------+------------
 admin    | bdbe4d376e6c8a53a791a86470b924c0715854bd353483523e3ab016eb55bcd0 | dummy_api_key | admin     |            |             | f
(1 row)
```
logs:
```
2024-09-18 14:08:42 2024-09-18 06:08:42,619 INFO sqlalchemy.engine.Engine COMMIT
2024-09-18 14:08:42 /backend/create_sql_tables.py:248: RemovedIn20Warning: Deprecated API features detected! These feature(s) are not compatible with SQLAlchemy 2.0. To prevent incompatible upgrades prior to updating applications, ensure requirements files are pinned to "sqlalchemy<2.0". Set environment variable SQLALCHEMY_WARN_20=1 to show all deprecation warnings.  Set environment variable SQLALCHEMY_SILENCE_UBER_WARNING=1 to silence this message. (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
2024-09-18 14:08:42   result = conn.execute(
2024-09-18 14:08:42 2024-09-18 06:08:42,620 INFO sqlalchemy.engine.Engine SELECT column_name FROM information_schema.columns WHERE table_name = 'defog_users' AND column_name = 'allowed_dbs';
2024-09-18 14:08:42 2024-09-18 06:08:42,620 INFO sqlalchemy.engine.Engine [raw sql] {}
```