### PR TITLE
Add an option to download and upload the metadata via CSV

### DIFF
--- a/backend/integration_routes.py
+++ b/backend/integration_routes.py
@@ -701,5 +701,4 @@ async def upload_metadata(request: Request):
         },
     )
 
-    r["metadata"] = metadata
     return r

--- a/frontend/components/extract-metadata/MetadataTable.js
+++ b/frontend/components/extract-metadata/MetadataTable.js
@@ -29,7 +29,6 @@ const MetadataTable = ({
   const [editingKeys, setEditingKeys] = useState({});
 
   const [loading, setLoading] = useState(false);
-  const [isUpdatedMetadata, setIsUpdatedMetadata] = useState(false);
   const [desc, setDesc] = useState({});
   const [filter, setFilter] = useState([]); // list of table names to filter
   const [form] = Form.useForm();
@@ -326,17 +325,16 @@ const MetadataTable = ({
           message.error("Error uploading metadata");
           return;
         } else {
-          const resp = await response.json();
           message.success("Metadata uploaded successfully!");
-          setMetadata(resp.metadata || []);
-          setFilteredMetadata(resp.metadata || []);
         }
       };
 
       reader.readAsText(file);
     };
 
+    setLoading(true);
     fileInput.click();
+    setLoading(false);
   };
 
   return (


### PR DESCRIPTION
Some users might prefer to upload and download the metadata via a CSV, instead of doing it by hand in the UI. This PR enables them to do this.

From a user email from Toyota

> I'm preparing golden queries + schema definition for more testing now - was wondering if there's a systematic way to ingest csv schema definitions? So far, I'm only seeing the individual column description edits on the extract metadata page. It'd be nice if I could download the metadata table csv (so I don't have to write a parser function to get the column data type), then bulk paste the column descriptions in. Would also be nice if I could upload select table and column descriptions in a csv to populate some of the blank ones.

We also clean up some of the frontend code, to use standardized React practices

![image](https://github.com/user-attachments/assets/68c3845b-8907-40ef-a645-f2c2e6c440b1)
