### PR TITLE
IMGO renaming and post running clarity

### DIFF
--- a/frontend/components/align-model/IMGO.js
+++ b/frontend/components/align-model/IMGO.js
@@ -323,8 +323,8 @@ const IMGO = ({ token, apiKeyName, updateGlossary, updateMetadata }) => {
 
   return (
     <>
-      <Button onClick={() => setModalVisible(true)} className="w-full">
-        Magic Finetune
+      <Button type="dashed" onClick={() => setModalVisible(true)} className="w-full mx-auto block">
+        Magic Finetune - Smart Optimization of Instructions and Metadata
       </Button>
       <Modal
         title={


### PR DESCRIPTION
Renaming IMGO to: `Magic Finetune - Smart Optimization of Instructions and Metadata`. Please feel free to change or recommend changes!


For the problem of it not being clear where the results for recommendations have come, we have a an arrow button appearing whenever a user scrolls down. This arrow button when clicked scrolls all the way up. But to make it more clear when the results are done running, this arrow button becomes green and animates at its position (goes up) with a message "Results are ready!". When clicked users see it scrolling up to show them the results of the IMGO run!

For testing, please uncomment IMGO from the `align_model.js` file.

<img width="1422" alt="Screenshot 2024-09-24 at 11 18 46 AM" src="https://github.com/user-attachments/assets/15410980-4076-4e37-83c2-20c43ce5a260">
<img width="1422" alt="Screenshot 2024-09-24 at 11 20 50 AM" src="https://github.com/user-attachments/assets/9a6df111-cf17-4862-aa94-512311dd0680">
