### PR TITLE
Refactor query-data.js to add loading spinner during API call

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2,7 +2,7 @@ import logging
 import os
 import traceback
 from fastapi import FastAPI, Request
-from fastapi.responses import FileResponse
+from fastapi.responses import FileResponse, JSONResponse
 from fastapi.middleware.cors import CORSMiddleware
 from connection_manager import ConnectionManager
 from agents.planner_executor.planner_executor_agent_rest import RESTExecutor

--- a/frontend/pages/query-data.js
+++ b/frontend/pages/query-data.js
@@ -77,7 +77,7 @@ const QueryDataPage = () => {
           {/* </div> */}
 
           {token ? (
-            true ? (
+            loading ? (
               <div className="w-full h-full flex justify-center items-center text-gray-400 text-sm">
                 Loading DBs <SpinningLoader classNames="ml-4" />
               </div>


### PR DESCRIPTION
This prevents an issue where the API key names were not updated on the `/query-data` page