### PR TITLE
Docker updates

### DIFF
--- a/backend/requirements_oracle.txt
+++ b/backend/requirements_oracle.txt
@@ -1,4 +1,4 @@
-airbyte==0.17.7
+airbyte==0.17.9
 celery[redis]==5.4.0
 markdown2[all]==2.5.0
 pdfkit==1.0.0

--- a/dockerfile.agents-python-server
+++ b/dockerfile.agents-python-server
@@ -1,5 +1,5 @@
 # builds image for the agents backend
-FROM python:3.10
+FROM python:3.11-slim
 
 WORKDIR /backend
 
@@ -9,8 +9,9 @@ RUN apt-get update && apt-get install -y python3-pip cmake netcat-openbsd wkhtml
 COPY ./backend/requirements_export.txt /root/requirements_export.txt
 COPY ./backend/requirements_oracle.txt /root/requirements_oracle.txt
 
-RUN pip install -r /root/requirements_export.txt
-RUN pip install -r /root/requirements_oracle.txt
+RUN pip install --upgrade pip setuptools && \
+  pip install -r /root/requirements_export.txt && \
+  pip install -r /root/requirements_oracle.txt
 
 # expose python server port
 EXPOSE 1235

--- a/dockerfile.agents-python-server-export
+++ b/dockerfile.agents-python-server-export
@@ -1,5 +1,5 @@
 # builds image for the agents backend
-FROM python:3.12
+FROM python:3.12-slim
 
 WORKDIR /backend
 


### PR DESCRIPTION
- Bump dev image to 3.11. The reason we can't use 3.12 is because `pendulum` (imported by airbyte) is <=3.0.0 and requires `distutils` which is removed in python 3.12. While the distutils dependency has been fixed in `pendulum`, airbyte has yet to update. See issue tracking that: https://github.com/airbytehq/PyAirbyte/issues/303. We can bump to 3.12 if they update (which doesn't seem to be anytime in the future).
- Use `slim` image for both. Alpine doesn't have `apt-get` so we need at least slim. Pushed to self-hosted-export with 3.12 to [staging](https://hub.docker.com/layers/defogai/agents-python-server/staging/images/sha256-5c3326872e31252f607137067753dd742569fd836fb7c9ff7b33ac60bb0b65f1?context=repo) for testing.
- Bump `airbyte` to latest.

Dev image size shrunk from 3.12GB to 2.41GB, which is great for more memory constrained environments!

Tested locally with the UI on a few pages including the query-data page, overall works fine for me.