### PR TITLE
Tiny PR #2: bump front end to 0.0.51

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "@ant-design/icons": "^5.4.0",
     "@azure/msal-browser": "^3.7.1",
     "@azure/msal-react": "^2.0.10",
-    "@defogdotai/agents-ui-components": "^0.0.50",
+    "@defogdotai/agents-ui-components": "^0.0.51",
     "@codemirror/lang-sql": "^6.7.0",
     "@dotlottie/react-player": "^1.6.12",
     "@marsidev/react-turnstile": "^0.4.1",


### PR DESCRIPTION
Bumps front end to 0.0.51, which has the fixes for "save as png" functionality in the charts