### PR TITLE
Cleanup `analyseDataResults` from local storage when on login page

### DIFF
--- a/frontend/pages/log-in.js
+++ b/frontend/pages/log-in.js
@@ -13,6 +13,8 @@ const LogIn = () => {
   useEffect(() => {
     // remove analysis trees whenever on the log in page
     localStorage.removeItem("analysisTrees");
+    // also remove stored analyse_data results (aka "step analysis")
+    localStorage.removeItem("analyseDataResults");
   });
 
   const handleLogin = async (event) => {


### PR DESCRIPTION
Removes stored analyseDataResults from local storage. Front end pr here: https://github.com/defog-ai/agents-ui-components/pull/57

Have tested this by:
1. Exporting using `npm run export`
2. Building the agents-nginx again: `docker compose up agents-nginx --build` (Add `-d` for detaching)
3. Visiting `localhost/` and asking a few questions.
4. Either refreshing and going to other pages and coming back to see that we make no network requests to `anlayse_data/`
5. Logging out and coming back to `localhost/query-data` to ensure everything was cleared.