### PR TITLE
Refactor imported data

### DIFF
--- a/backend/adhoc/insert_sample_imported_data.py
+++ b/backend/adhoc/insert_sample_imported_data.py
@@ -1,0 +1,32 @@
+# This script is meant to be run within the backend directory inside the docker
+# container, or anywhere the self-hosted postgres database is running.
+
+import requests
+import json
+
+base_url = "http://0.0.0.0:1235"
+
+payload = json.dumps(
+    {
+        "api_key": "123",
+        "data": [
+            ["product_name", "price", "quantity", "date_purchased", "card_number"],
+            ["apple", "1.00", "5", "2021-01-01", "4111111111111111"],
+            ["banana", "0.50", "10", "2021-01-02", "378282246310005"],
+            ["cherry", "2.00", "3", "2021-01-03", "6011000990139424"],
+            ["durian", "5.00", "1", "2021-01-04", "3530111333300000"],
+            ["elderberry", "3.00", "2", "2021-01-05", "5555555555554444"],
+        ],
+        "link": "https://example.com",
+        "table_index": 0,
+        "table_name": "fruit_products",
+        "table_description": "This table contains fruit products purchased by certain card numbers",
+    }
+)
+headers = {"Content-Type": "application/json"}
+
+response = requests.request(
+    "POST", f"{base_url}/import_table/create", headers=headers, data=payload
+)
+
+print(response.text)

--- a/backend/consumer_stripe.py
+++ b/backend/consumer_stripe.py
@@ -1,23 +1,19 @@
+import asyncio
+import functools
 import json
 import os
 import time
-import asyncio
-import functools
+from datetime import datetime
+from io import StringIO
+
 import airbyte as ab
 import pandas as pd
-from datetime import datetime
 import pika
-import csv
-from io import StringIO
+from db_utils import convert_cols_to_jsonb
+from generic_utils import make_request
+from utils_imported_data import update_imported_tables, update_imported_tables_db
 from utils_logging import LOGGER, save_and_log
 from utils_md import convert_data_type_postgres
-from db_utils import (
-    update_imported_tables_db,
-    update_imported_tables,
-    convert_cols_to_jsonb,
-)
-from generic_utils import make_request
-
 
 rabbitmq_host = os.environ.get("RABBITMQ_HOST", "localhost")
 parameters = pika.ConnectionParameters(host=rabbitmq_host)
@@ -30,7 +26,7 @@ channel.queue_declare(queue=queue_name)
 
 DEFOG_BASE_URL = os.environ.get("DEFOG_BASE_URL", "https://api.defog.ai")
 INTERNAL_DB = os.environ.get("INTERNAL_DB", "postgres")
-STRIPE_SCHEMA = "stripe" # schema name to store the stripe data
+STRIPE_SCHEMA = "stripe"  # schema name to store the stripe data
 STREAMS = [
     "customers",
     "persons",
@@ -386,7 +382,15 @@ async def callback(ch, method, properties, body):
 
         # update imported_tables database with the ga schema and tables
         link = "stripe"
-        update_imported_tables_db(link, table_index, table_name, csv_data, STRIPE_SCHEMA)
+        success, old_table_name = update_imported_tables_db(
+            link, table_index, table_name, csv_data, STRIPE_SCHEMA
+        )
+        if not success:
+            LOGGER.error(
+                f"Error in updating imported tables database for table {table_name}"
+            )
+            ch.basic_ack(delivery_tag=method.delivery_tag)
+            return
         schema_table_name = f"{STRIPE_SCHEMA}.{table_name}"
         inserted_tables[schema_table_name] = [
             {"data_type": data_type, "column_name": col_name, "column_description": ""}
@@ -403,7 +407,7 @@ async def callback(ch, method, properties, body):
 
         # update imported_tables table entries in internal db
         update_imported_tables(
-            link, table_index, schema_table_name, table_description=None
+            link, table_index, old_table_name, schema_table_name, table_description=None
         )
 
     # get and update metadata for {api_key}-imported
@@ -421,7 +425,12 @@ async def callback(ch, method, properties, body):
     try:
         response = await make_request(
             DEFOG_BASE_URL + "/update_metadata",
-            {"api_key": api_key, "table_metadata": md, "db_type": INTERNAL_DB, "imported": True},
+            {
+                "api_key": api_key,
+                "table_metadata": md,
+                "db_type": INTERNAL_DB,
+                "imported": True,
+            },
         )
         if response.get("status") == "success":
             LOGGER.info(

--- a/backend/data_connector_routes.py
+++ b/backend/data_connector_routes.py
@@ -1,20 +1,19 @@
-import os
 import json
-import pandas as pd
+import os
+from datetime import datetime
+from typing import Optional
+
+from db_utils import ORACLE_ENABLED, validate_user
 from fastapi import APIRouter
 from fastapi.responses import JSONResponse
-from datetime import datetime
-from io import StringIO
-from pydantic import BaseModel, Field
-from typing import Optional
-from db_utils import validate_user
 from generic_utils import get_api_key_from_key_name
+from pydantic import BaseModel, Field
 from utils_queue import publish
 
 router = APIRouter()
 
 DEFOG_BASE_URL = os.environ.get("DEFOG_BASE_URL", "https://api.defog.ai")
-if os.environ.get("ORACLE_ENABLED", "no") == "yes":
+if ORACLE_ENABLED:
     os.environ["RABBITMQ_PORT"] = "15672"
 
 

--- a/backend/imported_data_routes.py
+++ b/backend/imported_data_routes.py
@@ -1,0 +1,170 @@
+import os
+
+from fastapi import APIRouter, Request
+from fastapi.responses import JSONResponse
+from db_utils import INTERNAL_DB
+from generic_utils import make_request
+from utils_imported_data import (
+    IMPORTED_SCHEMA,
+    update_imported_tables,
+    update_imported_tables_db,
+)
+from utils_logging import LOGGER
+
+DEFOG_BASE_URL = os.environ.get("DEFOG_BASE_URL", "https://api.defog.ai")
+router = APIRouter()
+
+@router.post("/import_table/create")
+async def import_table_route(request: Request):
+    """
+    [Testing]
+    Route for importing a table from the request body into the imported database
+
+    Context:
+    To import data into the imported_tables database, we need to do 3 things:
+    1. Insert the data into the imported_tables database as a new table.
+        This is done by calling the `update_imported_tables_db` function.
+        It will update if the data's origin already exists in the database.
+    2. Insert the data's origin into the imported_tables database.
+        We need to keep track of each's data origin to be able to update the data
+        based on the origin later. E.g. if the 2nd table from a link is updated,
+        we want to know what the old table name was and delete that, before inserting
+        the new data and updating the imported_tables table.
+    3. Infer the column types/descriptions from the data.
+    4. Get and update the metadata to and from defog.
+
+    # Input format
+    {
+        "api_key": "123",
+        "data": [
+            ["product_name", "price", "quantity", "date_purchased", "card_number"],
+            ["apple", "1.00", "5", "2021-01-01", "4111111111111111"],
+            ["banana", "0.50", "10", "2021-01-02", "378282246310005"],
+            ["cherry", "2.00", "3", "2021-01-03", "6011000990139424"],
+        ],
+        "link": "https://example.com",
+        "table_index": 0,
+        "table_name": "fruit_products",
+        "table_description": "This table contains fruit products purchased by certain card numbers"
+    }
+    """
+    body = await request.json()
+    LOGGER.debug(f"Import table request body: {body}")
+    api_key = body.get("api_key")
+    data = body.get("data") # csv, includes columns in first row
+    link = body.get("link")
+    table_index = int(body.get("table_index", 0))
+    table_name = body.get("table_name")
+    table_description = body.get("table_description", "")
+
+    schema = body.get("schema", IMPORTED_SCHEMA)
+    success, old_table_name = update_imported_tables_db(
+        link=link,
+        table_index=table_index,
+        new_table_name=table_name,
+        data=data,
+        schema_name=schema,
+    )
+    if not success:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "error": "Server Error",
+                "message": "Failed to update imported tables database",
+            },
+        )
+    LOGGER.debug(f"Updated imported tables database with table: {table_name}")
+    LOGGER.debug(f"Old table name: {old_table_name}")
+
+    success = update_imported_tables(
+        link=link,
+        table_index=table_index,
+        old_table_name=old_table_name,
+        table_name=table_name,
+        table_description=table_description,
+    )
+    if not success:
+        return JSONResponse(
+            status_code=500,
+            content={
+                "error": "Server Error",
+                "message": "Failed to update imported tables database with the table origin",
+            },
+        )
+    infer_request = {
+        "api_key": api_key,
+        "all_rows": data,
+        "previous_text": None,
+    }
+    try:
+        table_properties = await make_request(
+            DEFOG_BASE_URL + "/unstructured_data/infer_table_properties",
+            infer_request,
+        )
+    except Exception as e:
+        LOGGER.error(f"Failed to infer table properties: {str(e)}")
+        return JSONResponse(
+            status_code=500,
+            content={
+                "error": "Server Error",
+                "message": "Failed to infer table properties",
+            },
+        )
+    if "columns" not in table_properties or "table_name" not in table_properties:
+        LOGGER.error(f"No columns or table name in table properties: {table_properties}")
+        return JSONResponse(
+            status_code=500,
+            content={
+                "error": "Server Error",
+                "message": "Failed to infer table properties",
+            },
+        )
+    if len(table_properties["columns"]) != len(data[0]):
+        LOGGER.error(f"Number of columns in table properties does not match data: {table_properties}")
+        return JSONResponse(
+            status_code=500,
+            content={
+                "error": "Server Error",
+                "message": "Failed to infer table properties",
+            },
+        )
+    md_new_table = {
+        table_properties["table_name"]: table_properties["columns"],
+    }
+    # TODO get imported metadata from defog, delete old table, insert new table
+    try:
+        response = await make_request(
+            url=f"{DEFOG_BASE_URL}/get_metadata", 
+            data={"api_key": api_key, "imported": True},
+        )
+        md = response.get("table_metadata", {})
+        if old_table_name and old_table_name in md:
+            del md[old_table_name]
+        md.update(md_new_table)
+        update_request = {
+            "api_key": api_key,
+            "table_metadata": md,
+            "imported": True,
+            "db_type": INTERNAL_DB
+        }
+        response = await make_request(
+            url=f"{DEFOG_BASE_URL}/update_metadata", 
+            data=update_request,
+        )
+    except Exception as e:
+        LOGGER.error(f"Failed to get and update metadata: {str(e)}")
+        return JSONResponse(
+            status_code=500,
+            content={
+                "error": "Server Error",
+                "message": "Failed to get and update metadata",
+            },
+        )
+    return JSONResponse(
+        status_code=200,
+        content={
+            "message": "Table imported successfully",
+            "table_name": table_name,
+        },
+    )
+    

--- a/backend/main.py
+++ b/backend/main.py
@@ -2,19 +2,19 @@ import logging
 import os
 import traceback
 from fastapi import FastAPI, Request
-from fastapi.responses import FileResponse, JSONResponse
+from fastapi.responses import FileResponse
 from fastapi.middleware.cors import CORSMiddleware
 from connection_manager import ConnectionManager
 from agents.planner_executor.planner_executor_agent_rest import RESTExecutor
 import doc_endpoints
 
 from db_utils import (
+    ORACLE_ENABLED,
     get_all_analyses,
     get_analysis_data,
     initialise_analysis,
-    get_user_key_names,
 )
-from generic_utils import get_api_key_from_key_name, make_request
+from generic_utils import get_api_key_from_key_name
 import integration_routes, query_routes, admin_routes, auth_routes, readiness_routes, csv_routes, feedback_routes, slack_routes, agent_routes, imgo_routes
 
 logging.basicConfig(level=logging.INFO)
@@ -34,11 +34,12 @@ app.include_router(imgo_routes.router)
 app.include_router(slack_routes.router)
 app.include_router(agent_routes.router)
 
-if os.environ.get("ORACLE_ENABLED", "no") == "yes":
-    import oracle_routes, data_connector_routes
+if ORACLE_ENABLED:
+    import data_connector_routes, imported_data_routes, oracle_routes
 
-    app.include_router(oracle_routes.router)
     app.include_router(data_connector_routes.router)
+    app.include_router(imported_data_routes.router)
+    app.include_router(oracle_routes.router)
 
     from oracle.setup import setup_dir
 

--- a/backend/oracle/utils_explore_data.py
+++ b/backend/oracle/utils_explore_data.py
@@ -5,10 +5,8 @@ import pandas as pd
 import base64
 
 from celery.utils.log import get_task_logger
-from generic_utils import format_sql, is_sorry, make_request, normalize_sql
+from generic_utils import format_sql, make_request, normalize_sql
 from utils_logging import LOG_LEVEL
-from sqlalchemy.ext.asyncio import create_async_engine
-from sqlalchemy import text
 import seaborn as sns
 
 DEFOG_BASE_URL = os.environ.get("DEFOG_BASE_URL", "https://api.defog.ai")

--- a/backend/startup.sh
+++ b/backend/startup.sh
@@ -17,8 +17,6 @@ while ! nc -z agents-redis $REDIS_INTERNAL_PORT; do
   echo "Waiting for ${REDIS_INTERNAL_PORT} to be available..."
   sleep 1
 done
-celery -A oracle.celery_app.celery_app worker --loglevel=info &
-python3 -m hypercorn main:app -b 0.0.0.0:1235 --reload &
 
 # Test for the RabbitMQ server to be up before starting the consumers
 max_retries=30
@@ -40,5 +38,8 @@ fi
 python3 consumer_google_analytics.py &
 python3 consumer_stripe.py &
 
-# Wait for all background jobs to finish
-wait
+# Start celery worker
+celery -A oracle.celery_app.celery_app worker --loglevel=info &
+
+# Start the FastAPI server
+python3 -m hypercorn main:app -b 0.0.0.0:1235 --reload

--- a/backend/utils_df.py
+++ b/backend/utils_df.py
@@ -9,11 +9,11 @@ TYPE_STRING = "string"
 TYPE_INTEGER = "int64"
 TYPE_FLOAT = "float64"
 
-REGEX_DATE_PATTERN = r'^\d{4}-\d{2}-\d{2}$'
-REGEX_TIME_PATTERN = r'^\d{2}:\d{2}:\d{2}$'
-REGEX_DATETIME_PATTERN = r'^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$'
-REGEX_INTEGER_PATTERN = r'^\d+$'
-REGEX_FLOAT_PATTERN = r'^\d+(\.\d+)?$'
+REGEX_DATE_PATTERN = r"^\d{4}-\d{2}-\d{2}$"
+REGEX_TIME_PATTERN = r"^\d{2}:\d{2}:\d{2}$"
+REGEX_DATETIME_PATTERN = r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$"
+REGEX_INTEGER_PATTERN = r"^\d+$"
+REGEX_FLOAT_PATTERN = r"^\d+(\.\d+)?$"
 
 
 def determine_column_type(column: pd.Series) -> str:
@@ -60,22 +60,20 @@ def mk_df(data: List, columns: List[str]) -> pd.DataFrame:
 
     for col in df.columns:
         column_non_null = df[col].dropna()
-        print(f"Non-null values in {col}: {column_non_null.tolist()}")  # Debugging line
         format_type = determine_column_type(column_non_null)
-        print(f"Column: {col}, Format: {format_type}")
-        
+
         if format_type == TYPE_DATETIME:
-            df[col] = pd.to_datetime(df[col], errors='coerce')
+            df[col] = pd.to_datetime(df[col], errors="coerce")
         elif format_type == TYPE_DATE:
-            df[col] = pd.to_datetime(df[col], errors='coerce')
+            df[col] = pd.to_datetime(df[col], errors="coerce")
         elif format_type == TYPE_TIME:
             # note that the .dt.time accessor coerces the type to 'object'
-            df[col] = pd.to_datetime(df[col], format='%H:%M:%S', errors='coerce').dt.time 
+            df[col] = pd.to_datetime(
+                df[col], format="%H:%M:%S", errors="coerce"
+            ).dt.time
         elif format_type == TYPE_INTEGER:
-            df[col] = pd.to_numeric(df[col], errors='coerce').astype('int64')
+            df[col] = pd.to_numeric(df[col], errors="coerce").astype("int64")
         elif format_type == TYPE_FLOAT:
-            df[col] = pd.to_numeric(df[col], errors='coerce').astype('float64')
-        
-        print(f"Final Data Type for {col}: {df[col].dtype}")  # Check final data type
-    
+            df[col] = pd.to_numeric(df[col], errors="coerce").astype("float64")
+
     return df

--- a/backend/utils_imported_data.py
+++ b/backend/utils_imported_data.py
@@ -1,0 +1,212 @@
+import logging
+from typing import List, Optional, Tuple
+
+from sqlalchemy import (
+    MetaData,
+    Table,
+    inspect as sql_inspect,
+    insert,
+    select,
+    text,
+    update,
+)
+from sqlalchemy.schema import DropTable
+
+from db_utils import (
+    IMPORTED_TABLES_DBNAME,
+    INTERNAL_DB,
+    ImportedTables,
+    imported_tables_engine,
+)
+from utils_df import mk_df
+from utils_logging import LOG_LEVEL
+
+
+IMPORTED_SCHEMA = "imported"  # schema name to store imported tables
+LOGGER = logging.getLogger(__name__)
+LOGGER.setLevel(LOG_LEVEL)
+
+
+def update_imported_tables_db(
+    link: str,
+    table_index: int,
+    new_table_name: str,
+    data: List[List[str]],
+    schema_name: str,
+) -> Tuple[bool, Optional[str]]:
+    """
+    Updates the IMPORTED_TABLES_DBNAME database with the new schema and table.
+    Replaces table from IMPORTED_TABLES_DBNAME database if it already exists.
+    data is a list of lists where the first list consists of the column names and the rest are the rows.
+    This function should always precede `update_imported_tables` as it first retrieves the old table name if the
+    table (defined by its link/index) already exists in the imported_tables table.
+    """
+    LOGGER.debug(f"Updating imported tables database with table: {new_table_name}")
+    # create schema in imported_tables db if it doesn't exist
+    try:
+        if INTERNAL_DB == "postgres":
+            # check if schema exists
+            inspector = sql_inspect(imported_tables_engine)
+            schema_names = inspector.get_schema_names()
+            schema_exists = schema_name in schema_names
+            if not schema_exists:
+                create_schema_stmt = f"CREATE SCHEMA {schema_name};"
+
+                with imported_tables_engine.begin() as imported_tables_connection:
+                    LOGGER.debug(
+                        f"inside with connection. creating schema:\n{create_schema_stmt}"
+                    )
+                    imported_tables_connection.execute(text(create_schema_stmt))
+                    LOGGER.info(
+                        f"Created schema `{schema_name}` in {IMPORTED_TABLES_DBNAME} database."
+                    )
+        else:
+            LOGGER.error(f"INTERNAL_DB is not postgres. Cannot create schema.")
+            return False, None
+    except Exception as e:
+        LOGGER.error(
+            f"Error creating schema `{schema_name}` in {IMPORTED_TABLES_DBNAME} database: {e}"
+        )
+        return False, None
+
+    # check if link and table_index already exist in imported_tables table
+    stmt = select(ImportedTables.table_name).where(
+        ImportedTables.table_link == link,
+        ImportedTables.table_position == table_index,
+    )
+
+    try:
+        with imported_tables_engine.begin() as imported_tables_connection:
+            result = imported_tables_connection.execute(stmt)
+            scalar_result = result.scalar()
+    except Exception as e:
+        LOGGER.error(
+            f"Error occurred in checking if entry `{link}` in position `{table_index}` exists in imported_tables table: {e}"
+        )
+        return False, None
+
+    if scalar_result is not None:
+        LOGGER.info(
+            f"Entry `{link}` in position `{table_index}` already exists in imported_tables table."
+        )
+        # get old table name without schema
+        old_table_name = scalar_result.split(".")[-1]
+        LOGGER.info(
+            f"Previous table name: `{old_table_name}`, New table name:  `{new_table_name}`"
+        )
+
+        # drop old table name if it already exists in imported_tables database
+
+        try:
+            with imported_tables_engine.begin() as imported_tables_connection:
+                inspector = sql_inspect(imported_tables_engine)
+                table_exists = inspector.has_table(old_table_name, schema=schema_name)
+                if table_exists:
+                    table = Table(old_table_name, MetaData(), schema=schema_name)
+                    drop_stmt = DropTable(table, if_exists=True)
+                    imported_tables_connection.execute(drop_stmt)
+                    LOGGER.info(
+                        f"Dropped existing table `{old_table_name}` from {IMPORTED_TABLES_DBNAME} database, schema `{schema_name}`."
+                    )
+        except Exception as e:
+            LOGGER.error(
+                f"Error dropping existing table `{old_table_name}` from {IMPORTED_TABLES_DBNAME} database, schema `{schema_name}`: {e}"
+            )
+            return False, old_table_name
+    else:
+        old_table_name = None
+        LOGGER.info(
+            f"Entry `{link}` in position `{table_index}` does not exist in imported_tables table."
+        )
+    try:
+        # insert the new table into imported_tables database
+        save_csv_to_db(new_table_name, data, schema_name=schema_name)
+        LOGGER.info(
+            f"Inserted table `{new_table_name}` into {IMPORTED_TABLES_DBNAME} database, schema `{schema_name}`."
+        )
+        return True, old_table_name
+    except Exception as e:
+        LOGGER.error(
+            f"Error inserting table `{new_table_name}` into {IMPORTED_TABLES_DBNAME} database, schema `{schema_name}`: {e}\n Data: {data}"
+        )
+        return False, old_table_name
+
+
+def update_imported_tables(
+    link: str,
+    table_index: int,
+    old_table_name: Optional[str],
+    table_name: str,
+    table_description: str,
+) -> bool:
+    """
+    Updates the imported_tables table in the imported_tables database with the table's info.
+    Removes entry from imported_tables table if it already exists.
+    """
+
+    if old_table_name:
+        try:
+            # update imported_tables table
+            update_stmt = (
+                update(ImportedTables)
+                .where(
+                    ImportedTables.table_link == link,
+                    ImportedTables.table_position == table_index,
+                )
+                .values(table_name=table_name, table_description=table_description)
+            )
+
+            with imported_tables_engine.begin() as imported_tables_connection:
+                imported_tables_connection.execute(update_stmt)
+                LOGGER.info(f"Updated entry `{table_name}` in imported_tables table.")
+            return True
+        except Exception as e:
+            LOGGER.error(
+                f"Error occurred in updating entry `{table_name}` in imported_tables table.: {e}"
+            )
+            return False
+    else:
+        try:
+            # insert the table's info into imported_tables table
+            table_data = {
+                "table_link": link,
+                "table_position": table_index,
+                "table_name": table_name,
+                "table_description": table_description,
+            }
+            stmt = insert(ImportedTables).values(table_data)
+            with imported_tables_engine.begin() as imported_tables_connection:
+                imported_tables_connection.execute(stmt)
+                LOGGER.info(
+                    f"Inserted entry `{table_name}` into imported_tables table."
+                )
+            return True
+        except Exception as e:
+            LOGGER.error(
+                f"Error occurred in inserting entry `{table_name}` into imported_tables table: {e}"
+            )
+            return False
+
+
+def save_csv_to_db(
+    table_name: str,
+    data: list[list[str]],
+    schema_name: str = None,
+) -> bool:
+    """
+    Saves a csv file to either the internal db or the imported_tables db.
+    data is a list of lists where the first list consists of the column names and the rest are the rows.
+    """
+    df = mk_df(data[1:], data[0])
+    try:
+        df.to_sql(
+            name=table_name,
+            con=imported_tables_engine,
+            if_exists="replace",
+            index=False,
+            schema=schema_name,
+        )
+        return True
+    except Exception as e:
+        LOGGER.error(e)
+        return False

--- a/backend/utils_sql.py
+++ b/backend/utils_sql.py
@@ -5,7 +5,6 @@ from typing import Dict
 import pandas as pd
 from pandas.testing import assert_frame_equal, assert_series_equal
 from sqlalchemy import text
-from db_utils import determine_date_format
 from utils_df import mk_df
 from utils_logging import LOGGER
 from sqlalchemy.ext.asyncio import create_async_engine

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
     deploy:
       resources:
         limits:
-          cpus: '1'
+          cpus: "1"
           memory: 512M
 
   agents-python-server:
@@ -70,6 +70,7 @@ services:
       context: .
       dockerfile: dockerfile.agents-python-server
     restart: always
+    stop_grace_period: 1s
     ports:
       - "1235:1235"
     volumes:
@@ -117,4 +118,4 @@ volumes:
   agents-rabbitmq:
 
 networks:
-  agents-network: 
+  agents-network:


### PR DESCRIPTION
# Motivation
The data importing functionality had no easy way for us to setup / test without going through the oracle, and was greatly reducing iteration velocity for the cross-database query testing. As such, we decided to shift out the data importing functionality into a separate set of utils + route to facilitate easier testing. We also uncover a critical bug that would cause the server to hang and fix it in the process.

# Changes
- shift out data importing from oracle/db_utils into `utils_imported_data.py` and `imported_data_routes.py`
- fix bug in `update_imported_tables_db` and `update_imported_tables` where 1 main connection with multiple transactions in it was causing the server to hang, and even become unable to handle all subsequent requests
- update downstream imports of imported data functionality (i.e. consumers)
- add test script for inserting test data into imported tables
- remove unused connection in `oracle/core.py`
- consolidate `ORACLE_ENABLED` into a bool that we can just import everywhere and use. `db_utils.py` is likely the best place since it contains a lot of state / connection management variables.
- shift hypercorn app startup to the final command in `startup.sh` so that the container is sensitive to the python process and will restart if the python hypercorn process crashes
- remove unnecessary printing in `mk_df`

# Testing

I started off by creating a new table:
```
curl --location '0.0.0.0:1235/import_table/create' \
--header 'Content-Type: application/json' \
--data '    {
        "api_key": "123",
        "data": [
            ["product_name", "price", "quantity", "date_purchased", "card_number"],
            ["apple", "1.00", "5", "2021-01-01", "4111111111111111"],
            ["banana", "0.50", "10", "2021-01-02", "378282246310005"],
            ["cherry", "2.00", "3", "2021-01-03", "6011000990139424"]
        ],
        "link": "https://example.com",
        "table_index": 0,
        "table_name": "fruit_products",
        "table_description": "This table contains fruit products purchased by certain card numbers"
    }'
```
In the postgres container:
```sh
$ docker exec -it defog-self-hosted-agents-postgres-1 /bin/bash -c "psql -U postgres -d postgres"
imported_tables=# SELECT * FROM imported.fruit_products;
 product_name | price | quantity |   date_purchased    |   card_number
--------------+-------+----------+---------------------+------------------
 apple        |     1 |        5 | 2021-01-01 00:00:00 | 4111111111111111
 banana       |   0.5 |       10 | 2021-01-02 00:00:00 |  378282246310005
 cherry       |     2 |        3 | 2021-01-03 00:00:00 | 6011000990139424
(3 rows)
```
I then issued another request with the same table name but with different data and slightly different types:
```
curl --location '0.0.0.0:1235/import_table/create' \
--header 'Content-Type: application/json' \
--data '{
    "api_key": "123",
    "data": [
        [
            "product_name",
            "card_number",
            "price",
            "quantity",
            "date_purchased"
        ],
        [
            "apple",
            "4111111111111111",
            "1",
            "5",
            "2023-01-01"
        ],
        [
            "banana",
            "378282246310005",
            "1",
            "10",
            "2023-01-02"
        ],
        [
            "cherry",
            "6011000990139424",
            "2",
            "3",
            "2023-01-03"
        ],
        [
            "durian",
            "3530111333300000",
            "10",
            "1",
            "2023-01-04"
        ],
        [
            "elderberry",
            "5555555555554444",
            "3",
            "2",
            "2023-01-05"
        ]
    ],
    "link": "https://example.com",
    "table_index": 0,
    "table_name": "fruit_products",
    "table_description": "This table contains fruit products purchased by certain card numbers"
}'
```
Now we have 5 rows of data (instead of 3 previously), card_number comes earlier, and price is a `bigint` instead of a numeric/float type:
```
imported_tables=# SELECT * FROM imported.fruit_products;
 product_name |   card_number    | price | quantity |   date_purchased
--------------+------------------+-------+----------+---------------------
 apple        | 4111111111111111 |     1 |        5 | 2023-01-01 00:00:00
 banana       |  378282246310005 |     1 |       10 | 2023-01-02 00:00:00
 cherry       | 6011000990139424 |     2 |        3 | 2023-01-03 00:00:00
 durian       | 3530111333300000 |    10 |        1 | 2023-01-04 00:00:00
 elderberry   | 5555555555554444 |     3 |        2 | 2023-01-05 00:00:00
(5 rows)

imported_tables=# \d imported.fruit_products
                        Table "imported.fruit_products"
     Column     |            Type             | Collation | Nullable | Default
----------------+-----------------------------+-----------+----------+---------
 product_name   | text                        |           |          |
 card_number    | bigint                      |           |          |
 price          | bigint                      |           |          |
 quantity       | bigint                      |           |          |
 date_purchased | timestamp without time zone |           |          |
```