### PR TITLE
Oracle Explorer Improvements

### DIFF
--- a/backend/generic_utils.py
+++ b/backend/generic_utils.py
@@ -20,7 +20,7 @@ if not DEFOG_API_KEYS:
 DEFOG_API_KEY_NAMES = os.environ.get("DEFOG_API_KEY_NAMES")
 
 
-async def make_request(url, data):
+async def make_request(url, data, timeout=60):
     if LOG_LEVEL == "DEBUG":
         LOGGER.debug(f"Making request to: {url}")
         # avoid excessively long logs (e.g. for base64 encoded images)
@@ -33,7 +33,7 @@ async def make_request(url, data):
         r = await client.post(
             url,
             json=data,
-            timeout=60,
+            timeout=timeout,
         )
     response = r.json()
     response_str = json.dumps(response, indent=2)


### PR DESCRIPTION
# Changes
As per the response format changes in https://github.com/defog-ai/defog-backend-python/pull/275, we will need to change the explorer behavior in DSH accordingly.
- save independent variable information in each question's outputs dictionary. we currently don't use the independent/dependent variable information, integrating that information for SQL gen, chart gen and analysis gen are planned subsequent work.
- save `chart_fn_params`, though we currently don't use it for generating the analysis. for future work.
- refactor explore to only have 1 round of question exploration since the questions all explore orthogonally different variables / columns that all have been selected from the metadata now.
- add timeout as a parameter in `make_request`. Add current default of 60s so the timeout behavior on all requests should still remain the same.

# Testing
Tested via the ui on http://localhost:1236/oracle-frontend by entering the question `Analysis of Home Purchase Behavior in Singapore` and not selecting any sources.
Alternatively, this curl requests works the same:
```
curl --location '0.0.0.0:1235/oracle/begin_generation' \
--header 'Content-Type: application/json' \
--data '{
    "token": "bdbe4d376e6c8a53a791a86470b924c0715854bd353483523e3ab016eb55bcd0",
    "key_name": "Housing",
    "user_question": "Analysis of Home Purchase Behavior in Singapore",
    "sources": [],
    "task_type": "exploration"
}'
```
A report with 5 meaningful questions was generated:
[report_21.pdf](https://github.com/user-attachments/files/17393551/report_21.pdf)
