### PR TITLE
Tiny PR: bump node lib to 0.0.56

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,7 +15,7 @@
     "@azure/msal-browser": "^3.7.1",
     "@azure/msal-react": "^2.0.10",
     "@codemirror/lang-sql": "^6.7.0",
-    "@defogdotai/agents-ui-components": "^0.0.55",
+    "@defogdotai/agents-ui-components": "^0.0.56",
     "@dotlottie/react-player": "^1.6.12",
     "@marsidev/react-turnstile": "^0.4.1",
     "@notionhq/client": "^2.2.14",


### PR DESCRIPTION
Includes tiny fixes for increasing header font sizes in sidebar. No functionality was changed.

<img width="343" alt="image" src="https://github.com/user-attachments/assets/86d75ee1-8d1b-44dc-9452-426bb89105fc">
