### PR TITLE
[Oracle] Remove get recommendations

### DIFF
--- a/backend/oracle/core.py
+++ b/backend/oracle/core.py
@@ -134,13 +134,11 @@ def next_stage(stage: str, task_type: str) -> str:
         return "explore"
     elif stage == "explore":
         if task_type == EXPLORATION:
-            return "recommendations"
+            return "export"
         elif task_type == PREDICTION:
             return "predict"
         elif task_type == OPTIMIZATION:
             return "optimize"
-    elif stage == "recommendations":
-        return "export"
     elif stage == "predict" and task_type == PREDICTION:
         return "export"
     elif stage == "optimize" and task_type == OPTIMIZATION:
@@ -179,15 +177,6 @@ async def execute_stage(
         )
     elif stage == "explore":
         stage_result = await explore_data(
-            api_key=api_key,
-            username=username,
-            report_id=report_id,
-            task_type=task_type,
-            inputs=inputs,
-            outputs=outputs,
-        )
-    elif stage == "recommendations":
-        stage_result = await get_recommendations(
             api_key=api_key,
             username=username,
             report_id=report_id,
@@ -474,17 +463,6 @@ async def gather_context(
     LOGGER.debug(f"Context gathered for report {report_id}:\n{combined_summary}")
     save_and_log(ts, "Combined summary", timings)
     return combined_summary
-
-
-async def get_recommendations(
-    api_key: str,
-    username: str,
-    report_id: str,
-    task_type: str,
-    inputs: Dict[str, Any],
-    outputs: Dict[str, Any],
-):
-    pass
 
 
 async def predict(

--- a/backend/oracle_routes.py
+++ b/backend/oracle_routes.py
@@ -29,10 +29,9 @@ async def clarify_question(req: Request):
     will return:
         clarifications: list[str]
         task_type: str
-        ready: bool
     Depending on the task type, the endpoint will return other additional fields.
-    Note that our UX has only been designed to display the clarifications, task_type,
-    and ready indicator for now. All other fields are not used by the client.
+    Note that our UX has only been designed to display the clarifications, and
+    task_type. All other fields are not used by the client.
     """
     body = await req.json()
     key_name = body.pop("key_name")

--- a/frontend/pages/oracle-frontend.js
+++ b/frontend/pages/oracle-frontend.js
@@ -7,7 +7,6 @@ import TaskType from "$components/oracle/TaskType";
 import setupBaseUrl from "$utils/setupBaseUrl";
 import {
   CheckCircleOutlined,
-  ExclamationCircleOutlined,
   CloseOutlined,
   DownloadOutlined,
   DeleteOutlined,
@@ -56,7 +55,6 @@ function OracleDashboard() {
   const [taskType, setTaskType] = useState("");
   const [sources, setSources] = useState([]);
   const [waitSources, setWaitSources] = useState(false);
-  const [ready, setReady] = useState(false);
   const [reports, setReports] = useState([]);
 
   const checkDBReady = async () => {
@@ -145,10 +143,8 @@ function OracleDashboard() {
       // we have the following fields to set:
       // - data.clarifications [list of string]
       // - data.task_type [string]
-      // - data.ready [bool]
       setTaskType(data.task_type);
       setClarifications(data.clarifications);
-      setReady(data.ready);
     } else {
       console.error("Failed to fetch clarifications");
     }
@@ -424,10 +420,8 @@ function OracleDashboard() {
                 userTask.length >= 5 &&
                 (!dataConnReady ? (
                   <CloseCircleOutlined style={{ color: "#b80617" }} />
-                ) : ready ? (
-                  <CheckCircleOutlined style={{ color: "green" }} />
                 ) : (
-                  <ExclamationCircleOutlined style={{ color: "#808080" }} />
+                  <CheckCircleOutlined style={{ color: "green" }} />
                 ))
               )}
             </div>


### PR DESCRIPTION
# Changes
- Remove unused stage in explore. We would prefer to implement that as part of a branch under the optimize task type, where depending on the question, we might choose a simple recommendation or a more complex mathematical optimization task.
- Remove `ready` field from the clarifications object. That was previously populated by the LLM response and not really a meaningful indicator of readiness. On the other hand, we do check for db readiness with the `dataConnReady` variable on the frontend, which is a concretely defined condition that we should verify.

# Testing
Frontend status indicator still works fine:

![status](https://github.com/user-attachments/assets/30c1124a-243d-436f-828b-b1926994d210)
 
