### PR TITLE
[Oracle] Prediction Export

### DIFF
--- a/backend/oracle/explore.py
+++ b/backend/oracle/explore.py
@@ -259,6 +259,7 @@ async def explore_generated_question(
 
     if data.empty:
         LOGGER.error(f"No data fetched for {qn_id}: {generated_qn}")
+        outputs["summary"] = "No data fetched"
         return outputs
 
     # choose appropriate visualization and generate chart

--- a/backend/oracle/utils_explore_data.py
+++ b/backend/oracle/utils_explore_data.py
@@ -7,6 +7,7 @@ from generic_utils import format_sql, make_request, normalize_sql
 from oracle.celery_app import LOGGER
 import seaborn as sns
 
+FIGSIZE = (5, 3)
 DEFOG_BASE_URL = os.environ.get("DEFOG_BASE_URL", "https://api.defog.ai")
 
 # explore module constants
@@ -125,7 +126,10 @@ async def get_chart_fn(
 
 
 def run_chart_fn(
-    chart_fn_params: Dict[str, Any], data: pd.DataFrame, chart_path: str, figsize=(5, 3)
+    chart_fn_params: Dict[str, Any],
+    data: pd.DataFrame,
+    chart_path: str,
+    figsize=FIGSIZE,
 ):
     """
     Run the sns plotting function on the data and save the chart to the given path.


### PR DESCRIPTION
# Changes
- Refactor `explore_generated_question` function to handle case when no data is fetched. This is useful for showing in the report, and for subsequent stages to reflect on when regenerating data for prediction/optimization
- Add ability to plot time-series forecasts, and save the charts. These charts will be used by the report generation step eventually.

This is the accompanying PR for https://github.com/defog-ai/defog-backend-python/pull/288

# Testing
Generated a report using the following initiation request:
```
curl --location '0.0.0.0:1235/oracle/begin_generation' \
--header 'Content-Type: application/json' \
--data '{
    "token": "bdbe4d376e6c8a53a791a86470b924c0715854bd353483523e3ab016eb55bcd0",
    "key_name": "Housing",
    "user_question": "Predict home purchase prices in Singapore for the next year",
    "sources": [],
    "task_type": "prediction"
}'
```
[report_52.pdf](https://github.com/user-attachments/files/17552127/report_52.pdf)

Trained model: 
[model.json](https://github.com/user-attachments/files/17552129/model.json)

