### PR TITLE
[Oracle] Consolidate checks and error handling

### DIFF
--- a/backend/db_utils.py
+++ b/backend/db_utils.py
@@ -4,6 +4,7 @@ import inspect
 import logging
 import os
 import traceback
+from typing import Dict, Tuple
 import uuid
 
 import redis
@@ -154,14 +155,11 @@ def convert_cols_to_jsonb(
         return False
 
 
-def get_db_type_creds(api_key):
+def get_db_type_creds(api_key: str) -> Tuple[str, Dict[str, str]]:
     with engine.begin() as conn:
         row = conn.execute(
             select(DbCreds.db_type, DbCreds.db_creds).where(DbCreds.api_key == api_key)
         ).fetchone()
-
-    LOGGER.debug(row)
-
     return row
 
 

--- a/backend/oracle/core.py
+++ b/backend/oracle/core.py
@@ -120,6 +120,8 @@ async def begin_generation_async_task(
                 stmt = select(OracleReports).where(OracleReports.report_id == report_id)
                 result = session.execute(stmt)
                 report = result.scalar_one()
+                outputs[stage.value] = {"error": str(e) + "\n" + traceback.format_exc()}
+                report.outputs = outputs
                 report.status = "error"
                 session.commit()
             continue_generation = False

--- a/backend/oracle_routes.py
+++ b/backend/oracle_routes.py
@@ -3,7 +3,9 @@ import time
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from db_utils import OracleReports, engine, validate_user
+import requests
+
+from db_utils import OracleReports, engine, get_db_type_creds, validate_user
 from fastapi import APIRouter, Request
 from fastapi.responses import FileResponse, JSONResponse
 from generic_utils import get_api_key_from_key_name, make_request


### PR DESCRIPTION
# Changes
This PR addresses some feedback provided about error visibility in 2 ways:
1. Consolidate checks for key sources of errors at `/integration/check`. The frontend now only makes a single call, simplifying the frontend code, while allowing us to provide more comprehensive pre-emptive checks as needed via a single authenticated backend request. This is slightly safer than passing `db_creds` back and forth between the front and backend.
2. Output error traceback into the outputs dictionary whenever a report fails to generate for us to trace the source of the error

# Testing

## Invalid Token

![invalid token](https://github.com/user-attachments/assets/30110bca-f103-454d-9428-b4c0b32082c3)

## No db creds

![db creds](https://github.com/user-attachments/assets/e273dcee-96e8-4bc2-b063-fa62ae5c863d)

## Defog API not reachable

![not reachable](https://github.com/user-attachments/assets/8de4d945-97d4-4b29-9724-fd084a9acc7d)

