### PR TITLE
[Oracle] Fixes

### DIFF
--- a/backend/consumer_google_analytics.py
+++ b/backend/consumer_google_analytics.py
@@ -240,7 +240,7 @@ async def callback(ch, method, properties, body):
         # update imported_tables database with the ga schema and tables
         link = "google_analytics"
         success, old_table_name = update_imported_tables_db(
-            link, table_index, table_name, csv_data, GOOGLE_ANALYTICS_SCHEMA
+            api_key, link, table_index, table_name, csv_data, GOOGLE_ANALYTICS_SCHEMA
         )
         if not success:
             LOGGER.error(
@@ -264,7 +264,12 @@ async def callback(ch, method, properties, body):
 
         # update imported_tables table entries in internal db
         update_imported_tables(
-            link, table_index, old_table_name, schema_table_name, table_description=None
+            api_key,
+            link,
+            table_index,
+            old_table_name,
+            schema_table_name,
+            table_description=None,
         )
 
     # get and update metadata for {api_key}-imported

--- a/backend/consumer_stripe.py
+++ b/backend/consumer_stripe.py
@@ -383,7 +383,7 @@ async def callback(ch, method, properties, body):
         # update imported_tables database with the ga schema and tables
         link = "stripe"
         success, old_table_name = update_imported_tables_db(
-            link, table_index, table_name, csv_data, STRIPE_SCHEMA
+            api_key, link, table_index, table_name, csv_data, STRIPE_SCHEMA
         )
         if not success:
             LOGGER.error(
@@ -407,7 +407,12 @@ async def callback(ch, method, properties, body):
 
         # update imported_tables table entries in internal db
         update_imported_tables(
-            link, table_index, old_table_name, schema_table_name, table_description=None
+            api_key,
+            link,
+            table_index,
+            old_table_name,
+            schema_table_name,
+            table_description=None,
         )
 
     # get and update metadata for {api_key}-imported

--- a/backend/create_imported_tables_db.py
+++ b/backend/create_imported_tables_db.py
@@ -4,7 +4,7 @@ from sqlalchemy import (
     MetaData,
     Table,
     Column,
-    Float,
+    Integer,
     Text,
     text,
 )
@@ -15,8 +15,9 @@ imported_metadata = MetaData()
 imported_tables = Table(
     "imported_tables",
     imported_metadata,
+    Column("api_key", Text, primary_key=True),
     Column("table_link", Text, primary_key=True),
-    Column("table_position", Float, primary_key=True),
+    Column("table_position", Integer, primary_key=True),
     Column("table_name", Text),
     Column("table_description", Text),
 )

--- a/backend/create_sql_tables.py
+++ b/backend/create_sql_tables.py
@@ -173,6 +173,7 @@ oracle_clarifications = Table(
 oracle_sources = Table(
     "oracle_sources",
     metadata,
+    Column("api_key", Text, primary_key=True),
     Column("link", Text, primary_key=True),
     Column("title", Text),
     Column("position", Integer),

--- a/backend/db_utils.py
+++ b/backend/db_utils.py
@@ -263,6 +263,7 @@ if ORACLE_ENABLED:
 
     class OracleSources(Base):
         __tablename__ = "oracle_sources"
+        api_key = Column(Text, primary_key=True)
         link = Column(Text, primary_key=True)
         title = Column(Text)
         position = Column(Integer)
@@ -282,8 +283,9 @@ if ORACLE_ENABLED:
 
         class ImportedTables(ImportedTablesBase):
             __tablename__ = "imported_tables"
+            api_key = Column(Text, primary_key=True)
             table_link = Column(Text, primary_key=True)
-            table_position = Column(Integer)
+            table_position = Column(Integer, primary_key=True)
             table_name = Column(Text)
             table_description = Column(Text)
 

--- a/backend/oracle/core.py
+++ b/backend/oracle/core.py
@@ -381,7 +381,7 @@ async def gather_context(
                 # create the table and insert the data into imported_tables database, parsed schema
                 data = [column_names] + rows
                 success, old_table_name = update_imported_tables_db(
-                    link, table_index, table_name, data, IMPORTED_SCHEMA
+                    api_key, link, table_index, table_name, data, IMPORTED_SCHEMA
                 )
                 if not success:
                     LOGGER.error(
@@ -390,6 +390,7 @@ async def gather_context(
                     continue
                 # update the imported_tables table in internal db
                 update_imported_tables(
+                    api_key,
                     link,
                     table_index,
                     old_table_name,

--- a/backend/startup.sh
+++ b/backend/startup.sh
@@ -9,7 +9,7 @@ if [ "$INTERNAL_DB" = "postgres" ]; then
 fi
 
 python3 create_sql_tables.py
-python3 create_new_dbs.py
+python3 create_imported_tables_db.py
 python3 create_admin_user.py
 python3 add_tools_to_db.py
 # test if REDIS_INTERNAL_PORT is up, and sleep until it is

--- a/backend/utils_imported_data.py
+++ b/backend/utils_imported_data.py
@@ -26,6 +26,7 @@ IMPORTED_SCHEMA = "imported"  # schema name to store imported tables
 LOGGER = logging.getLogger(__name__)
 LOGGER.setLevel(LOG_LEVEL)
 
+
 def get_source_type(link: str) -> str:
     if "http" in link:
         return "webpage"
@@ -35,7 +36,9 @@ def get_source_type(link: str) -> str:
         LOGGER.error(f"Unknown source type for link: {link}")
         return "unknown"
 
+
 def update_imported_tables_db(
+    api_key: str,
     link: str,
     table_index: int,
     new_table_name: str,
@@ -49,7 +52,9 @@ def update_imported_tables_db(
     This function should always precede `update_imported_tables` as it first retrieves the old table name if the
     table (defined by its link/index) already exists in the imported_tables table.
     """
-    LOGGER.debug(f"Updating imported tables database with table: {new_table_name}")
+    LOGGER.debug(
+        f"Updating imported tables database with schema.table: `{schema_name}.{new_table_name}`"
+    )
     # create schema in imported_tables db if it doesn't exist
     try:
         if INTERNAL_DB == "postgres":
@@ -79,6 +84,7 @@ def update_imported_tables_db(
 
     # check if link and table_index already exist in imported_tables table
     stmt = select(ImportedTables.table_name).where(
+        ImportedTables.api_key == api_key,
         ImportedTables.table_link == link,
         ImportedTables.table_position == table_index,
     )
@@ -141,6 +147,7 @@ def update_imported_tables_db(
 
 
 def update_imported_tables(
+    api_key: str,
     link: str,
     table_index: int,
     old_table_name: Optional[str],
@@ -158,6 +165,7 @@ def update_imported_tables(
             update_stmt = (
                 update(ImportedTables)
                 .where(
+                    ImportedTables.api_key == api_key,
                     ImportedTables.table_link == link,
                     ImportedTables.table_position == table_index,
                 )
@@ -177,6 +185,7 @@ def update_imported_tables(
         try:
             # insert the table's info into imported_tables table
             table_data = {
+                "api_key": api_key,
                 "table_link": link,
                 "table_position": table_index,
                 "table_name": table_name,


### PR DESCRIPTION
# Motivation
Our initial design of allowing all sources to be accessed by everybody isn't ideal for testing, especially when we start adding multiple api_keys with disparate datasets. For example, we might only want to see the housing related sources for api_key `456`, while we want to see only restaurants related sources for api_key `test_restaurant`, since unrelated sources could easily confuse the oracle during the context gathering. Duplicating sources across `api_key` is trivial (storage-wise and processing) so adding this is just pure backend legwork.

# Changes
- [Breaking] add `api_key` to `oracle_sources` and `imported_tables` tables to differentiate sources. updated all upstream table creation code and downstream usages. 
- fixed `/sources/list` endpoint to get _all_ sources first, and then the imported tables from each source. this will return sources with no imported tables now.
- renamed `create_new_dbs.py` to `create_imported_tables_db.py` for clarity that it's only for imported tables.

# Testing

## Setup

To begin, if you haven't imported any sources or want to keep any imported sources (it's fine to delete, a better UI is coming!), you can do the following to reinitialize the tables.

```
# remove oracle_sources first from postgres database, then the imported_tables table and all imported tables
$ docker exec -it defog-self-hosted-agents-postgres-1 /bin/bash -c "psql -U postgres -d postgres"

psql (16.4)
Type "help" for help.

postgres=# DROP TABLE oracle_sources;
DROP TABLE
postgres=# \c imported_tables
You are now connected to database "imported_tables" as user "postgres".
imported_tables=# SELECT table_name FROM imported_tables;
                    table_name
--------------------------------------------------
 imported.residential_property_price_changes_2023
(1 row)
```
Note that your current state might have more or less tables, just drop them accordingly, and then the imported_tables finally.
```
imported_tables=# DROP TABLE imported.residential_property_price_changes_2023;
DROP TABLE
imported_tables=# DROP TABLE imported_tables;
DROP TABLE
```
You can then restart your docker containers for self-hosted:
```sh
docker compose down && docker compose up -d
```
The `backend/create_sql_tables.py` and `backend/create_imported_tables_db.py` scripts should create the new `oracle_sources` and `imported_tables` definitions accordingly.

## Test requests

We use a series of 6 requests (similar to https://github.com/defog-ai/defog-self-hosted/pull/250):
1. list empty state
2. import 1 source with table
3. import 1 source without table
4. list state (should show both sources now)
5. delete source with table
6. list state (should show remaining source without table)

### List Empty State
```
curl --location '0.0.0.0:1235/sources/list' \
--header 'Content-Type: application/json' \
--data '{
    "token": "bdbe4d376e6c8a53a791a86470b924c0715854bd353483523e3ab016eb55bcd0",
    "key_name": "Housing",
    "preview_rows": 2
}'
```
```json
{}
```

### Import Source With Table

```
curl --location '0.0.0.0:1235/sources/import' \
--header 'Content-Type: application/json' \
--data '{
    "token": "bdbe4d376e6c8a53a791a86470b924c0715854bd353483523e3ab016eb55bcd0",
    "key_name": "Housing",
    "sources": [
        {
            "link": "https://www.jll.com.sg/en/newsroom/ura-4q23-real-estate-statistics"
        }
    ]
}'
```
```json
{
    "message": "Sources imported successfully"
}
```

### Import Source Without Table
We use the [bitter lesson](http://www.incompleteideas.net/IncIdeas/BitterLesson.html) by Rich Sutton:
```
curl --location '0.0.0.0:1235/sources/import' \
--header 'Content-Type: application/json' \
--data '{
    "token": "bdbe4d376e6c8a53a791a86470b924c0715854bd353483523e3ab016eb55bcd0",
    "key_name": "Housing",
    "sources": [
        {
            "link": "http://www.incompleteideas.net/IncIdeas/BitterLesson.html"
        }
    ]
}'
```


### List Imported Sources

```
curl --location '0.0.0.0:1235/sources/list' \
--header 'Content-Type: application/json' \
--data '{
    "token": "bdbe4d376e6c8a53a791a86470b924c0715854bd353483523e3ab016eb55bcd0",
    "key_name": "Housing",
    "preview_rows": 2
}'
```
```json
{
    "http://www.incompleteideas.net/IncIdeas/BitterLesson.html": {
        "source_title": "",
        "source_type": "webpage",
        "source_summary": "```md\n# The Bitter Lesson  \n\n## Rich Sutton\n\n### March 13, 2019  \n\nThe biggest lesson that can be read from 70 years of AI research is that general methods that leverage computation are ultimately the most effective, and by a large margin. The ultimate reason for this is Moore's law, or rather its generalization of continued exponentially falling cost per unit of computation. Most AI research has been conducted as if the computation available to the agent were constant (in which case leveraging human knowledge would be one of the only ways to improve performance) but, over a slightly longer time than a typical research project, massively more computation inevitably becomes available. Seeking an improvement that makes a difference in the shorter term, researchers seek to leverage their human knowledge of the domain, but the only thing that matters in the long run is the leveraging of computation. \n\nThere are psychological commitments to investment in one approach or the other. And the human-knowledge approach tends to complicate methods in ways that make them less suited to taking advantage of general methods leveraging computation. There were many examples of AI researchers' belated learning of this bitter lesson, and it is instructive to review some of the most prominent.  \n\nIn computer chess, the methods that defeated the world champion, Kasparov, in 1997, were based on massive, deep search. At the time, this was looked upon with dismay by the majority of computer-chess researchers who had pursued methods that leveraged human understanding of the special structure of chess. \n\nA similar pattern of research progress was seen in computer Go, only delayed by a further 20 years. Enormous initial efforts went into avoiding search by taking advantage of human knowledge, or of the special features of the game, but all those efforts proved irrelevant, or worse, once search was applied effectively at scale. Also important was the use of learning by self play to learn a value function. Learning by self play, and learning in general, is like search in that it enables massive computation to be brought to bear. Search and learning are the two most important classes of techniques for utilizing massive amounts of computation in AI research. \n\nIn speech recognition, there was an early competition, sponsored by DARPA, in the 1970s. Entrants included a host of special methods that took advantage of human knowledge. On the other side were newer methods that were more statistical in nature and did much more computation, based on hidden Markov models (HMMs). Again, the statistical methods won out over the human-knowledge-based methods. This led to a major change in all of natural language processing, gradually over decades, where statistics and computation came to dominate the field. \n\nIn computer vision, there has been a similar pattern. Early methods conceived of vision as searching for edges, or generalized cylinders, or in terms of SIFT features. But today all this is discarded. Modern deep-learning neural networks use only the notions of convolution and certain kinds of invariances, and perform much better.  \n\nThis is a big lesson. As a field, we still have not thoroughly learned it, as we are continuing to make the same kind of mistakes. We have to learn the bitter lesson that building in how we think we think does not work in the long run. The bitter lesson is based on the historical observations that 1) AI researchers have often tried to build knowledge into their agents, 2) this always helps in the short term, and is personally satisfying to the researcher, but 3) in the long run it plateaus and even inhibits further progress, and 4) breakthrough progress eventually arrives by an opposing approach based on scaling computation by search and learning. \n\nOne thing that should be learned from the bitter lesson is the great power of general purpose methods, of methods that continue to scale with increased computation even as the available computation becomes very great. The two methods that seem to scale arbitrarily in this way are search and learning.  \n\nThe second general point to be learned from the bitter lesson is that the actual contents of minds are tremendously, irredeemably complex; we should stop trying to find simple ways to think about the contents of minds. Instead we should build in only the meta-methods that can find and capture this arbitrary complexity. Essential to these methods is that they can find good approximations, but the search for them should be by our methods, not by us. We want AI agents that can discover like we can, not which contain what we have discovered. Building in our discoveries only makes it harder to see how the discovering process can be done.  \n```",
        "tables": []
    },
    "https://www.jll.com.sg/en/newsroom/ura-4q23-real-estate-statistics": {
        "source_title": "",
        "source_type": "webpage",
        "source_summary": "```md\n# URA 4Q23 real estate statistics\n\n## Residential\n\n### 2023 ends well for private homes sales market\n\nAll things considered, the private residential market demonstrated resilience in 2023, overcoming a range of challenges including market cooling measures, a dim economic outlook, high property prices, elevated mortgage rates and inflation to achieve a full year price growth of 6.8%.\n\n### Total sales volume in 2023 fell on heightened caution\n\nIn 4Q23, the **primary home sales market** was slower than the previous quarter but more active than in 4Q22. The 1,060 new private homes (excluding executive condominiums or ECs) launched in 4Q23 was 62.2% lower q-o-q but 110.3% higher y-o-y. Developer sales of 1,092 private residential units also dropped 43.9% q-o-q but was 58.3% higher y-o-y.\n\nThe top selling projects in the primary market in 2023 were The Reserve Residences (663 units), Grand Dunman (616 units), Lentor Hill Residences (438 units), Tembusu Grand (377 units) and J’den (326 units).\n\nThe sales performance of these projects shows that buyers, despite being price conscious and highly discerning, are **still drawn to projects that offer strong product quality and desirable locational attributes** even if they come with a higher price tag. They gravitate towards properties that are conveniently situated near important amenities like MRT stations and have the potential for growth. Locations that have a scarcity of new supply also tend to generate pent-up demand among buyers.\n\n### Prices maintain a growth trajectory\n\nResidential property prices continued to climb in 4Q23, rising at a faster q-o-q pace of 2.8% compared to 0.8% q-o-q in 3Q23. This growth was propped up by the robust sales of the non-landed launches of J’den and Watten House.\n\nThe overall price increase in 2023 was driven by the landed housing market, where prices continued to climb by 8.0% y-o-y, albeit at a moderated pace compared to 2022 and 2021. Potential homebuyers continue to lean towards landed homes due to their aspirations for such scarce property types and their preferences for larger indoor and outdoor spaces.\n\nIn the non-landed segment, prices rose by 6.6% y-o-y in 2023, propelled by the 13.7% y-o-y price surge for non-landed homes in the OCR, which is faster than the 9.3% y-o-y increase in 2022 and 8.8% in 2021. Buying demand from **local residents** for suburban non-landed homes for their own occupancy and new project launches at higher price points have strengthened the price growth in the OCR.\n\n### Guarded optimism with a mild price growth projected for 2024\n\nOur outlook for 2024 is one of guarded optimism, with expectations of a fairly **resilient home sales market**.\n\nForeign buyers and investors will remain deterred by the stricter ABSD measures, while buyers' homeownership aspirations and genuine demand from local buyers purchasing for their own occupancy will continue to underpin private sales.\n\nNevertheless, it is expected that prospective homebuyers will be driven to commit when presented with appealing and captivating projects, as evident by the recent successful launches of J’den and Watten House.\n\nOverall **private home prices** are projected to rise by 3% to 5% in 2024.\n```",
        "tables": [
            {
                "table_name": "imported.residential_property_price_changes_2023",
                "table_description": "A table showing the percentage change in residential property prices across different regions for the third and fourth quarters of 2023.",
                "table_head": [
                    [
                        "Non-landed",
                        2.2,
                        2.3
                    ],
                    [
                        "CCR",
                        -2.7,
                        3.9
                    ]
                ],
                "table_count": 5
            }
        ]
    }
}
```

### Delete Source With Table

```
curl --location '0.0.0.0:1235/sources/delete' \
--header 'Content-Type: application/json' \
--data '{
    "token": "bdbe4d376e6c8a53a791a86470b924c0715854bd353483523e3ab016eb55bcd0",
    "key_name": "Housing",
    "link": "https://www.jll.com.sg/en/newsroom/ura-4q23-real-estate-statistics"
}'
```
```json
{
    "message": "Source deleted successfully"
}
```

### List Remaining Source Without Table

```
curl --location '0.0.0.0:1235/sources/list' \
--header 'Content-Type: application/json' \
--data '{
    "token": "bdbe4d376e6c8a53a791a86470b924c0715854bd353483523e3ab016eb55bcd0",
    "key_name": "Housing",
    "preview_rows": 2
}'
```
```json
{
    "http://www.incompleteideas.net/IncIdeas/BitterLesson.html": {
        "source_title": "",
        "source_type": "webpage",
        "source_summary": "```md\n# The Bitter Lesson  \n\n## Rich Sutton\n\n### March 13, 2019  \n\nThe biggest lesson that can be read from 70 years of AI research is that general methods that leverage computation are ultimately the most effective, and by a large margin. The ultimate reason for this is Moore's law, or rather its generalization of continued exponentially falling cost per unit of computation. Most AI research has been conducted as if the computation available to the agent were constant (in which case leveraging human knowledge would be one of the only ways to improve performance) but, over a slightly longer time than a typical research project, massively more computation inevitably becomes available. Seeking an improvement that makes a difference in the shorter term, researchers seek to leverage their human knowledge of the domain, but the only thing that matters in the long run is the leveraging of computation. \n\nThere are psychological commitments to investment in one approach or the other. And the human-knowledge approach tends to complicate methods in ways that make them less suited to taking advantage of general methods leveraging computation. There were many examples of AI researchers' belated learning of this bitter lesson, and it is instructive to review some of the most prominent.  \n\nIn computer chess, the methods that defeated the world champion, Kasparov, in 1997, were based on massive, deep search. At the time, this was looked upon with dismay by the majority of computer-chess researchers who had pursued methods that leveraged human understanding of the special structure of chess. \n\nA similar pattern of research progress was seen in computer Go, only delayed by a further 20 years. Enormous initial efforts went into avoiding search by taking advantage of human knowledge, or of the special features of the game, but all those efforts proved irrelevant, or worse, once search was applied effectively at scale. Also important was the use of learning by self play to learn a value function. Learning by self play, and learning in general, is like search in that it enables massive computation to be brought to bear. Search and learning are the two most important classes of techniques for utilizing massive amounts of computation in AI research. \n\nIn speech recognition, there was an early competition, sponsored by DARPA, in the 1970s. Entrants included a host of special methods that took advantage of human knowledge. On the other side were newer methods that were more statistical in nature and did much more computation, based on hidden Markov models (HMMs). Again, the statistical methods won out over the human-knowledge-based methods. This led to a major change in all of natural language processing, gradually over decades, where statistics and computation came to dominate the field. \n\nIn computer vision, there has been a similar pattern. Early methods conceived of vision as searching for edges, or generalized cylinders, or in terms of SIFT features. But today all this is discarded. Modern deep-learning neural networks use only the notions of convolution and certain kinds of invariances, and perform much better.  \n\nThis is a big lesson. As a field, we still have not thoroughly learned it, as we are continuing to make the same kind of mistakes. We have to learn the bitter lesson that building in how we think we think does not work in the long run. The bitter lesson is based on the historical observations that 1) AI researchers have often tried to build knowledge into their agents, 2) this always helps in the short term, and is personally satisfying to the researcher, but 3) in the long run it plateaus and even inhibits further progress, and 4) breakthrough progress eventually arrives by an opposing approach based on scaling computation by search and learning. \n\nOne thing that should be learned from the bitter lesson is the great power of general purpose methods, of methods that continue to scale with increased computation even as the available computation becomes very great. The two methods that seem to scale arbitrarily in this way are search and learning.  \n\nThe second general point to be learned from the bitter lesson is that the actual contents of minds are tremendously, irredeemably complex; we should stop trying to find simple ways to think about the contents of minds. Instead we should build in only the meta-methods that can find and capture this arbitrary complexity. Essential to these methods is that they can find good approximations, but the search for them should be by our methods, not by us. We want AI agents that can discover like we can, not which contain what we have discovered. Building in our discoveries only makes it harder to see how the discovering process can be done.  \n```",
        "tables": []
    }
}
```