### PR TITLE
[Oracle] Manage Sources

### DIFF
--- a/backend/imported_tables_routes.py
+++ b/backend/imported_tables_routes.py
@@ -137,6 +137,7 @@ async def sources_import_route(req: ImportSourcesRequest):
     json_data = {
         "api_key": api_key,
         "sources": sources_to_parse,
+        "resummarize": True,
     }
     # each source now contains "text" and "summary" keys
     sources_parsed = await make_request(

--- a/frontend/pages/test-regression.tsx
+++ b/frontend/pages/test-regression.tsx
@@ -6,7 +6,6 @@ import {
   CheckCircleOutlined,
   CloseCircleOutlined,
   InboxOutlined,
-  MinusOutlined,
 } from "@ant-design/icons";
 
 import CodeMirror, { EditorView } from "@uiw/react-codemirror";


### PR DESCRIPTION
- Added a new page for managing sources. Handles CRUD for sources using the routes in imported_tables_routes.py
- Updated `/sources/import` to take in list of strings directly instead of a list of dictionaries. we can make it more complex in the future if required.

Accompanying PR: https://github.com/defog-ai/defog-backend-python/pull/306

See demo loom: https://www.loom.com/share/d3adc5e3a0aa4fefbf8eed44bd067ab8?sid=f9f1db4a-d3bb-4be3-987e-7de151322c48

Next step would be to add the tables for each source under each source's section.