### PR TITLE
Request params fixed for generation endpoint

### DIFF
--- a/frontend/pages/oracle-frontend.js
+++ b/frontend/pages/oracle-frontend.js
@@ -337,8 +337,10 @@ function OracleDashboard() {
   const generateReport = async () => {
     // generate a report
     const token = localStorage.getItem("defogToken");
-    const selectedSources = sources.filter((source) => source.selected);
-    console.log("Selected sources:", selectedSources);
+    const selectedSourceLinks = sources
+      .filter((source) => source.selected) // Filter to only selected sources
+      .map((source) => source.link); // Extract the 'link' property of the source
+    console.log("Selected sources:", selectedSourceLinks);
 
     //
 
@@ -351,7 +353,7 @@ function OracleDashboard() {
         token,
         key_name: apiKeyName,
         user_question: userQuestion,
-        sources: selectedSources,
+        sources: selectedSourceLinks,
         task_type: taskType,
         clarifications: clarifications.map((d) => ({
           ...d,


### PR DESCRIPTION
According to the pydantic class for begin generation:
```
class BeginGenerationRequest(BaseModel):
    key_name: str
    token: str
    user_question: str
    task_type: TaskType
    sources: List[str]
    clarifications: List[Dict[str, Any]]
```
the sources is supposed to be a list of strings and each string is a link to the source (confirmed with @wongjingping).

The frontend was sending a dictionary of list where each object contains details like title, link etc about the source. This was causing a 442 error. We fix this by mapping the list of objects of selected sources to their links.

Response now:
`{"report_id":1,"status":"started"}`