### PR TITLE
[Oracle] Sources State Fix

### DIFF
--- a/frontend/components/oracle/Sources.js
+++ b/frontend/components/oracle/Sources.js
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { PlusOutlined, CheckOutlined } from "@ant-design/icons";
 import Image from "next/image";
 
@@ -23,21 +22,22 @@ export default function Sources({ sources, setSources }) {
 }
 
 const SourceCard = ({ source, setSources }) => {
-  const [selected, setSelected] = useState(source.selected);
   const handleSelect = () => {
-    setSelected(!selected);
     setSources((prevSources) =>
       prevSources.map((prevSource) => {
         if (prevSource.link === source.link) {
-          return { ...prevSource, selected: !selected };
+          return { ...prevSource, selected: !prevSource.selected };
         }
         return prevSource;
       })
     );
   };
+
   return (
     <div
-      className={`"flex h-[79px] w-full items-center gap-2.5 rounded-lg border border-gray-100 px-1.5 py-1 shadow-md ${selected ? "bg-gray-100 opacity-50" : "bg-white"}`}
+      className={`flex h-[79px] w-full items-center gap-2.5 rounded-lg border border-gray-100 px-1.5 py-1 shadow-md ${
+        source.selected ? "bg-gray-100 opacity-50" : "bg-white"
+      }`}
     >
       <div className="flex items-center relative">
         <span className="shrink-0">
@@ -65,7 +65,7 @@ const SourceCard = ({ source, setSources }) => {
           className="ml-auto cursor-pointer top-2 right-2"
           onClick={handleSelect}
         >
-          {selected ? (
+          {source.selected ? (
             <CheckOutlined style={{ color: "green" }} />
           ) : (
             <PlusOutlined />


### PR DESCRIPTION
I change the question which changes the sources which is awesome! But the new sources had a state reload issue where even if they were not selected they would appear selected. 
E.g.: 
I had `[source1, source3, source5] `with my current question and when I click generate these go in as expected!
When I change question the sources themselves change and even the selected sources is `[]` but it still appears on the UI that `[source1, source3, source5]` are selected. Now when we click generate, the following happens:
<img width="1359" alt="Screenshot 2024-11-19 at 3 06 17 AM" src="https://github.com/user-attachments/assets/db9da778-1e60-46aa-9fb3-07a959302bc8">
As can be seen above, the sources that was sent was actually empty but some sources appear as selected due to what I will call "state carry forward"!

Fix: Made `Sources` component dependent on props sources instead of creating their own local state!