### PR TITLE
Fix Insertion of Test Records

### DIFF
--- a/backend/adhoc/insert_user_db_creds.py
+++ b/backend/adhoc/insert_user_db_creds.py
@@ -70,12 +70,12 @@ with engine.begin() as conn:
 
         # check if user exists and update
         user_result = conn.execute(
-            select(Users).where(Users.token == hashed_password)
+            select(Users).where(Users.username == username)
         ).fetchone()
         if user_result:
             conn.execute(
                 update(Users)
-                .where(Users.token == hashed_password)
+                .where(Users.username == username)
                 .values(
                     username=username,
                     hashed_password=hashed_password,


### PR DESCRIPTION
There would be duplicate data conflicts if username=admin has already been inserted. We find similar username's instead of tokens to update.

Previously:
```
$ docker exec -it defog-self-hosted-agents-python-server-1 /bin/bash -c "python adhoc/insert_user_db_creds.py"
Setting log level to DEBUG
INFO: ORACLE_ENABLED: True
using postgres as our internal db
INFO: Created imported tables engine for postgres: Engine(postgresql://postgres:***@agents-postgres:5432/imported_tables)
INFO: Created temp tables engine for postgres: Engine(postgresql://postgres:***@agents-postgres:5432/temp_tables)
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1967, in _exec_single_context
    self.dialect.do_execute(
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/engine/default.py", line 941, in do_execute
    cursor.execute(statement, parameters)
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "defog_users_pkey"
DETAIL:  Key (username)=(admin) already exists.


The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/backend/adhoc/insert_user_db_creds.py", line 87, in <module>
    conn.execute(
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1418, in execute
    return meth(
           ^^^^^
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/sql/elements.py", line 515, in _execute_on_connection
    return connection._execute_clauseelement(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1640, in _execute_clauseelement
    ret = self._execute_context(
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1846, in _execute_context
    return self._exec_single_context(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1986, in _exec_single_context
    self._handle_dbapi_exception(
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 2355, in _handle_dbapi_exception
    raise sqlalchemy_exception.with_traceback(exc_info[2]) from e
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/engine/base.py", line 1967, in _exec_single_context
    self.dialect.do_execute(
  File "/usr/local/lib/python3.11/site-packages/sqlalchemy/engine/default.py", line 941, in do_execute
    cursor.execute(statement, parameters)
sqlalchemy.exc.IntegrityError: (psycopg2.errors.UniqueViolation) duplicate key value violates unique constraint "defog_users_pkey"
DETAIL:  Key (username)=(admin) already exists.

[SQL: INSERT INTO defog_users (username, hashed_password, token, user_type, created_at) VALUES (%(username)s, %(hashed_password)s, %(token)s, %(user_type)s, %(created_at)s)]
[parameters: {'username': 'admin', 'hashed_password': 'bdbe4d376e6c8a53a791a86470b924c0715854bd353483523e3ab016eb55bcd0', 'token': 'bdbe4d376e6c8a53a791a86470b924c0715854bd353483523e3ab016eb55bcd0', 'user_type': 'admin', 'created_at': datetime.datetime(2024, 11, 19, 7, 44, 55, 534830)}]
(Background on this error at: https://sqlalche.me/e/20/gkpj)
```

Now:
```
$ docker exec -it defog-self-hosted-agents-python-server-1 /bin/bash -c "python adhoc/insert_user_db_creds.py"
Setting log level to DEBUG
INFO: ORACLE_ENABLED: True
using postgres as our internal db
INFO: Created imported tables engine for postgres: Engine(postgresql://postgres:***@agents-postgres:5432/imported_tables)
INFO: Created temp tables engine for postgres: Engine(postgresql://postgres:***@agents-postgres:5432/temp_tables)
User admin updated.
Token to use for admin: bdbe4d376e6c8a53a791a86470b924c0715854bd353483523e3ab016eb55bcd0
User card updated.
Token to use for card: 0cc5a005b7e60e81ac15333e6ba20090389fde19740c691d2e614c7f4bf5a4e5
User housing updated.
Token to use for housing: a0568ab889a24b7efd93b2e11f1050aee85796d54aa8df75d89f673d26b86643
User restaurant updated.
Token to use for restaurant: 77eaded23c3fff6b68d490e3146bfd738411b6083f1cc73503af075315830fd7
User macmillan updated.
Token to use for macmillan: 340a2e515002825d24137acf145802fc9ce19f1165daa525449d95f0d32e3990
DbCreds for api_key=123 updated.
DbCreds for api_key=456 updated.
DbCreds for api_key=test_restaurant updated.
DbCreds for api_key=test_macmillan updated.
```