### PR TITLE
[Oracle] Year Fix

### DIFF
--- a/backend/adhoc/insert_user_db_creds.py
+++ b/backend/adhoc/insert_user_db_creds.py
@@ -47,6 +47,10 @@ databases = [
         "api_key": "test_macmillan",
         "database": "macmillan",
     },
+    {
+        "api_key": "fbc046431bd131d1c6c55c782d8bbd413a339d9c78ec6da6fea73cdfaeacb897",
+        "database": "macmillan",
+    },
 ]
 DB_CREDS = {
     "host": "host.docker.internal",

--- a/backend/tests/test_utils_df.py
+++ b/backend/tests/test_utils_df.py
@@ -1,5 +1,7 @@
+from decimal import Decimal
 import unittest
 import pandas as pd
+from pandas.testing import assert_series_equal
 from utils_df import determine_column_type, mk_df
 
 
@@ -21,9 +23,11 @@ class TestDetermineColumnType(unittest.TestCase):
         data = pd.Series(["2021-01-01", "2021-01-02", "2021-01-03"])
         self.assertEqual(determine_column_type(data), "date")
         data = pd.Series(["2021-01", "2021-02", "2021-03"])
-        self.assertEqual(determine_column_type(data), "date")
+        self.assertEqual(determine_column_type(data), "string")
+
+    def test_year_column(self):
         data = pd.Series(["2021", "2022", "2023"])
-        self.assertEqual(determine_column_type(data), "date")
+        self.assertEqual(determine_column_type(data), "int64")
 
     def test_time_column(self):
         data = pd.Series(["12:00:00", "13:00:00", "14:00:00"])
@@ -68,12 +72,49 @@ class TestMkDf(unittest.TestCase):
 
     def test_date_column(self):
         data = [
-            ["2021-01-01", "2021-01-02", "2021-01-03"],
-            ["2021-01-04", "2021-01-05", "2021-01-06"],
+            ["2021-01-01", "2021-01-02"],
+            ["2021-01-04", "2021-01-05"],
+        ]
+        columns = ["col1", "col2"]
+        df = mk_df(data, columns)
+        assert_series_equal(
+            df["col1"],
+            pd.Series(["2021-01-01", "2021-01-04"], dtype="datetime64[ns]"),
+            check_dtype=True,
+            check_names=False,
+        )
+        assert_series_equal(
+            df["col2"],
+            pd.Series(["2021-01-02", "2021-01-05"], dtype="datetime64[ns]"),
+            check_dtype=True,
+            check_names=False,
+        )
+
+    def test_year_column(self):
+        data = [
+            (Decimal("2021"), "1990", "2001-01"),
+            (Decimal("2022"), "2022-01", "2002-04"),
         ]
         columns = ["col1", "col2", "col3"]
         df = mk_df(data, columns)
-        self.assertTrue((df.dtypes == "datetime64[ns]").all())
+        assert_series_equal(
+            df["col1"], pd.Series([2021, 2022]), check_dtype=True, check_names=False
+        )
+        assert_series_equal(
+            df["col2"],
+            pd.Series(["1990", "2022-01"]),
+            check_dtype=True,
+            check_names=False,
+        )
+        assert_series_equal(
+            df["col3"],
+            pd.Series(["2001-01", "2002-04"]),
+            check_dtype=True,
+            check_names=False,
+        )
+        self.assertTrue(pd.api.types.is_integer_dtype(df["col1"]))
+        self.assertTrue(pd.api.types.is_object_dtype(df["col2"]))
+        self.assertTrue(pd.api.types.is_object_dtype(df["col3"]))
 
     def test_time_column(self):
         data = [
@@ -101,7 +142,47 @@ class TestMkDf(unittest.TestCase):
         ]
         columns = ["col1", "col2", "col3"]
         df = mk_df(data, columns)
-        print(df.dtypes)
         self.assertTrue(pd.api.types.is_object_dtype(df["col1"]))
         self.assertTrue(pd.api.types.is_float_dtype(df["col2"]))
         self.assertTrue(pd.api.types.is_object_dtype(df["col3"]))
+
+    def test_mixed_types_2(self):
+        data = [
+            (Decimal("2023"), "Student Store", 11926004, None),
+            (Decimal("2024"), "Student Store", 7813075, Decimal("-34.48")),
+        ]
+        columns = [
+            "enrollment_year",
+            "channel",
+            "total_activations",
+            "percentage_change",
+        ]
+        df = mk_df(data, columns)
+        assert_series_equal(
+            df["enrollment_year"],
+            pd.Series([2023, 2024]),
+            check_dtype=True,
+            check_names=False,
+        )
+        assert_series_equal(
+            df["channel"],
+            pd.Series(["Student Store", "Student Store"]),
+            check_dtype=True,
+            check_names=False,
+        )
+        assert_series_equal(
+            df["total_activations"],
+            pd.Series([11926004, 7813075]),
+            check_dtype=True,
+            check_names=False,
+        )
+        assert_series_equal(
+            df["percentage_change"],
+            pd.Series([None, Decimal("-34.48")]),
+            check_dtype=True,
+            check_names=False,
+        )
+        self.assertTrue(pd.api.types.is_integer_dtype(df["enrollment_year"]))
+        self.assertTrue(pd.api.types.is_object_dtype(df["channel"]))
+        self.assertTrue(pd.api.types.is_integer_dtype(df["total_activations"]))
+        self.assertTrue(pd.api.types.is_object_dtype(df["percentage_change"]))

--- a/backend/utils_df.py
+++ b/backend/utils_df.py
@@ -9,7 +9,7 @@ TYPE_STRING = "string"
 TYPE_INTEGER = "int64"
 TYPE_FLOAT = "float64"
 
-REGEX_DATE_PATTERN = r"^\d{4}(-\d{2})?(-\d{2})?$"
+REGEX_DATE_PATTERN = r"^\d{4}-\d{2}-\d{2}$"
 REGEX_TIME_PATTERN = r"^\d{2}:\d{2}:\d{2}$"
 REGEX_DATETIME_PATTERN = r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$"
 REGEX_INTEGER_PATTERN = r"^\d+$"

--- a/backend/utils_sql.py
+++ b/backend/utils_sql.py
@@ -58,7 +58,7 @@ async def execute_sql(
             colnames = list(result.keys())
             data_str = truncate_obj([tuple(row) for row in data])
             LOGGER.info(
-                f"Query successfully executed. Col names: {colnames}, Data: {data_str}\nSQL: {sql}"
+                f"Query successfully executed.\nCol names: {colnames}\nData: {data_str}\nSQL: {sql}"
             )
             df = mk_df(data, colnames)
     except Exception as e:


### PR DESCRIPTION
# Problem
We were not getting year's populated, because of a mismatch between what we accepted to be date string formats "YYYY", "YYYY-MM", "YYYY-MM-DD", vs pandas' to_datetime conversion, which can only convert "YYYY-MM-DD" by default. In addition, setting `pd.to_datetime(df[col], errors="coerce")` will coerce to a datetime type, causing all non-convertible types (i.e.  "YYYY-MM" and "YYYY" strings) to become `NaT` (equivalent of `NaN` but for time values), and often resulting in the year column getting dropped because it's empty.

# Fix
We now restrict our date regex string to only match "YYYY-MM-DD" formats, leaving "YYYY" as integer and "YYYY-MM" as string. We rarely get dates in "YYYY-MM" format, and can create a rule for that case if we do encounter such data in the future. The integer representation of a year is sufficient for downstream aggregations / plotting (since proportions hold as well as the datetime types).

# Testing
Updated and fixed unit tests to test for the _actual values_ and not just the dtypes.
Generated a sample report and it now shows the year:

![year_shows](https://github.com/user-attachments/assets/01134e20-1576-4a73-a8c3-8a05d5f35542)

[report_year_fix.pdf](https://github.com/user-attachments/files/17815520/report_year_fix.pdf)



