### PR TITLE
[Oracle] Polling for listing reports fixed

### DIFF
--- a/frontend/pages/oracle-frontend.js
+++ b/frontend/pages/oracle-frontend.js
@@ -201,7 +201,7 @@ function OracleDashboard() {
     }
   };
 
-  const fetchReports = async (apiKeyName, setReportsCallback) => {
+  const fetchReports = useCallback(async (apiKeyName, setReportsCallback) => {
     try {
       const token = localStorage.getItem("defogToken");
       if (!token || !apiKeyName) return;
@@ -229,7 +229,7 @@ function OracleDashboard() {
       console.error("An error occurred while fetching reports:", error);
       return null;
     }
-  };
+  }, []);
 
   useEffect(() => {
     const fetchInitialReports = async () => {


### PR DESCRIPTION
Thanks to @jp for reporting this bug on the frontend! 

Currently, there's this bug where we keep polling `/oracle/list_reports` on the oracle-frontend page at `1s` interval.

Desired:
When the page loads, we do not need to poll when listing for the first time!

Consequently, we should only poll if there's a report generation request sent from the frontend, and once that report id has reached a terminal state (i.e. `error` or `done`), then we can stop polling.

We use `isPolling` state to manage when to poll! Additionally, we define a function `fetchReports` that is then used both reports the first time and polling when needed.

