### PR TITLE
Add front end envs to docker hub

### DIFF
--- a/docker-compose-hub.yaml
+++ b/docker-compose-hub.yaml
@@ -1,4 +1,4 @@
-version: '3.8'
+version: "3.8"
 
 services:
   agents-postgres:
@@ -52,6 +52,12 @@ services:
       - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
       - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION}
       - DELETE_EXISTING_TOOLS=${DELETE_EXISTING_TOOLS:-no}
+
+      # front end non-admin config
+      - HIDE_SQL_TAB_FOR_NON_ADMIN=${HIDE_SQL_TAB_FOR_NON_ADMIN}
+      - HIDE_PREVIEW_TABS_FOR_NON_ADMIN=${HIDE_PREVIEW_TABS_FOR_NON_ADMIN}
+      - HIDDEN_CHARTS_FOR_NON_ADMIN=${HIDDEN_CHARTS_FOR_NON_ADMIN}
+      - HIDE_RAW_ANALYSIS_FOR_NON_ADMIN=${HIDE_RAW_ANALYSIS_FOR_NON_ADMIN}
     volumes:
       - agents-assets:/agents-assets/
     depends_on:


### PR DESCRIPTION
Same as https://github.com/defog-ai/defog-self-hosted/pull/279

But now add them to docker hub file as well:

```
# set to "yes" if you want to hide the SQL/Code tab for non-admin users
HIDE_SQL_TAB_FOR_NON_ADMIN=

# set to "yes" if you want to hide the preview data and view data structure tabs for non-admin users
HIDE_PREVIEW_TABS_FOR_NON_ADMIN=

# comma separated list of chart names. all lowercase.
# can be: line, bar, scatter, histogram, boxplot
HIDDEN_CHARTS_FOR_NON_ADMIN=

# set to "yes" if you want to hide the raw analysis tab for non-admin users
HIDE_RAW_ANALYSIS_FOR_NON_ADMIN=
```