### PR TITLE
Deleting a report to update past reports without reloading

### DIFF
--- a/frontend/pages/oracle-frontend.js
+++ b/frontend/pages/oracle-frontend.js
@@ -351,19 +351,33 @@ function OracleDashboard() {
   };
 
   const deleteReport = async (report_id) => {
-    // delete a report
+    // Fetch the token from localStorage
     const token = localStorage.getItem("defogToken");
-    const res = await fetch(setupBaseUrl("http", `oracle/delete_report`), {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        token,
-        key_name: apiKeyName,
-        report_id: report_id,
-      }),
-    });
+
+    try {
+      // Send delete request to the API
+      const res = await fetch(setupBaseUrl("http", `oracle/delete_report`), {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          token,
+          key_name: apiKeyName,
+          report_id: report_id,
+        }),
+      });
+
+      if (res.ok) {
+        // Re-fetch reports after successful deletion
+        console.log("Report deleted successfully");
+        await fetchReports(apiKeyName, setReports);
+      } else {
+        console.error("Failed to delete report");
+      }
+    } catch (error) {
+      console.error("Error deleting report:", error);
+    }
   };
 
   const generateReport = async () => {


### PR DESCRIPTION
This PR updates the `deleteReport` function to ensure the "Past Reports" list reflects the latest state immediately after a report is deleted, without requiring a manual page reload.

Changes Made:
Modified the `deleteReport` function to re-fetch the updated reports list using `fetchReports` after a successful delete operation.
Ensured proper error handling and logging for the delete operation.