### PR TITLE
Add json_schema_extra to existing pydantic models

### DIFF
--- a/backend/data_connector_routes.py
+++ b/backend/data_connector_routes.py
@@ -21,12 +21,23 @@ class DataConnectorRequest(BaseModel):
     """
     Request body for data connector endpoints.
     """
-
     key_name: str
     token: str
     data_start_date: Optional[str] = Field(
         default="1900-01-01", description="Start date for data retrieval"
     )
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "key_name": "my_api_key",
+                    "token": "user_token",
+                    "data_start_date": "1900-01-01"
+                }
+            ]
+        }
+    }
 
 
 @router.post("/connector/get_google_analytics_data")
@@ -167,7 +178,7 @@ async def get_stripe_data(request: DataConnectorRequest):
                 "message": "RABBITMQ_PORT env var not set",
             },
         )
-    # check that the data_start_date is in the correct format YYYY-MM-DD
+    # check that the data_start_date is in the correct format YYYY-MM-DDThh:mm:ssZ
     try:
         datetime.strptime(data_start_date, "%Y-%m-%dT%H:%M:%SZ")
     except ValueError:

--- a/backend/imported_tables_routes.py
+++ b/backend/imported_tables_routes.py
@@ -39,6 +39,18 @@ class SourcesListRequest(BaseModel):
     key_name: str
     preview_rows: Optional[int] = None
 
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "token": "user_token",
+                    "key_name": "source_key",
+                    "preview_rows": 10
+                }
+            ]
+        }
+    }
+
 
 @router.post("/sources/list")
 async def sources_list_route(req: SourcesListRequest):
@@ -123,6 +135,18 @@ class ImportSourcesRequest(BaseModel):
     token: str
     key_name: str
     links: List[str]
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "token": "user_token",
+                    "key_name": "source_key",
+                    "links": ["https://example.com/source1", "https://example.com/source2"]
+                }
+            ]
+        }
+    }
 
 
 @router.post("/sources/import")
@@ -318,6 +342,18 @@ class DeleteSourceRequest(BaseModel):
     key_name: str
     link: str
 
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "token": "user_token",
+                    "key_name": "source_key",
+                    "link": "https://example.com/source1"
+                }
+            ]
+        }
+    }
+
 
 @router.post("/sources/delete")
 async def delete_source(req: DeleteSourceRequest):
@@ -387,6 +423,25 @@ class CreateImportedTablesRequest(BaseModel):
     table_index: int
     table_name: str
     table_description: str = ""
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "token": "user_token",
+                    "key_name": "source_key",
+                    "data": [
+                        ["column1", "column2"],
+                        ["value1", "value2"]
+                    ],
+                    "link": "https://example.com/source1",
+                    "table_index": 0,
+                    "table_name": "example_table",
+                    "table_description": "Example table description"
+                }
+            ]
+        }
+    }
 
 
 @router.post("/imported_tables/create")

--- a/backend/integration_routes.py
+++ b/backend/integration_routes.py
@@ -44,6 +44,17 @@ class CheckRequest(BaseModel):
     token: str
     key_name: str
 
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "token": "user_token",
+                    "key_name": "integration_key"
+                }
+            ]
+        }
+    }
+
 
 @router.post("/integration/check")
 async def check_route(req: CheckRequest):

--- a/backend/oracle_routes.py
+++ b/backend/oracle_routes.py
@@ -41,6 +41,20 @@ class ClarifyQuestionRequest(BaseModel):
     task_type: Optional[TaskType] = None
     answered_clarifications: List[Dict[str, Any]] = []
 
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "key_name": "my_api_key",
+                    "token": "user_token",
+                    "user_question": "What are the sales trends?",
+                    "task_type": None,
+                    "answered_clarifications": []
+                }
+            ]
+        }
+    }
+
 
 @router.post("/oracle/clarify_question")
 async def clarify_question(req: ClarifyQuestionRequest):
@@ -189,6 +203,21 @@ class BeginGenerationRequest(BaseModel):
     task_type: TaskType
     sources: List[str]
     clarifications: List[Dict[str, Any]]
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "key_name": "my_api_key",
+                    "token": "user_token",
+                    "user_question": "What are the sales trends?",
+                    "task_type": "analysis",
+                    "sources": ["source1", "source2"],
+                    "clarifications": [{"question": "answer"}]
+                }
+            ]
+        }
+    }
 
 
 @router.post("/oracle/begin_generation")
@@ -357,6 +386,17 @@ class GetReportRequest(BaseModel):
     key_name: str
     report_id: int
 
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "key_name": "my_api_key",
+                    "report_id": 1
+                }
+            ]
+        }
+    }
+
 
 @router.post("/oracle/get_report_mdx")
 async def get_report_mdx(req: GetReportRequest):
@@ -430,6 +470,18 @@ class GetReportImageRequest(BaseModel):
     report_id: int | str
     image_file_name: str
 
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "key_name": "my_api_key",
+                    "report_id": 1,
+                    "image_file_name": "chart.png"
+                }
+            ]
+        }
+    }
+
 
 @router.post("/oracle/get_report_image")
 async def get_report_image(req: GetReportImageRequest):
@@ -464,6 +516,18 @@ class OracleReportFeedbackRequest(BaseModel):
     key_name: str
     report_id: int
     feedback: str
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "key_name": "my_api_key",
+                    "report_id": 1,
+                    "feedback": "Great report!"
+                }
+            ]
+        }
+    }
 
 
 @router.post("/oracle/feedback_report")

--- a/backend/user_history_routes.py
+++ b/backend/user_history_routes.py
@@ -36,6 +36,18 @@ class UpdateHistoryRequest(BaseModel):
     key_name: str
     history: dict
 
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "token": "user_token",
+                    "key_name": "history_key",
+                    "history": {"data": "history_data"}
+                }
+            ]
+        }
+    }
+
 
 @router.post("/update_user_history")
 async def update_user_history(request: UpdateHistoryRequest):


### PR DESCRIPTION
This adds the `json_schema_extra` param to all pydantic models on all endpoints. This makes it much easier to go the the `/docs` page on localhost:1235 and easily test out a request from the browser.

Example: http://localhost:1235/docs#/default/get_report_data_oracle_get_report_data_post

Note that this does not apply to all endpoints. It only applies to the endpoints that already have a Pydantic schema defined, and NOT to endpoints that have a generic `Request` object defined.

This PR was done 100% by Windsurf!