### PR TITLE
[Oracle] Executive Summary

### DIFF
--- a/backend/oracle/explore.py
+++ b/backend/oracle/explore.py
@@ -236,11 +236,11 @@ async def explore_generated_question(
     - generated_qn: str
     - dependent_variable: Dict[str, Any]
         - description: str
-        - table.column: List[str]
+        - table_column: List[str]
     - independent_variable_group: Dict[str, Any]
         - name: str
         - description: str
-        - table.column: List[str]
+        - table_column: List[str]
     - artifacts: Dict[str, Dict[str, str]]
         - outer key: str, artifact type, one of FETCHED_TABLE_CSV, TABLE_CSV, IMAGE
         - inner keys
@@ -300,8 +300,8 @@ async def explore_generated_question(
             elif err_msg is not None:
                 LOGGER.error(f"Error occurred in executing SQL: {err_msg}")
             elif isinstance(data, pd.DataFrame) and data.empty:
-                dependent_variable_str = f"{dependent_variable['description']} ({dependent_variable['table.column']})"
-                independent_variable_str = f"{independent_variable_group['description']} ({independent_variable_group['table.column']})"
+                dependent_variable_str = f"{dependent_variable['description']} ({dependent_variable['table_column']})"
+                independent_variable_str = f"{independent_variable_group['description']} ({independent_variable_group['table_column']})"
                 expand_sql_qn_response = await make_request(
                     DEFOG_BASE_URL + "/oracle/expand_sql_qn",
                     data={
@@ -351,13 +351,14 @@ async def explore_generated_question(
             )
         }
     }
+    LOGGER.debug(f"independent_variable_group: {independent_variable_group}")
     outputs = {
         "qn_id": qn_id,
         "generated_qn": generated_qn,
         "independent_variable_group": {
             "name": independent_variable_group["name"],
             "description": independent_variable_group["description"],
-            "table.column": independent_variable_group["table.column"],
+            "table_column": independent_variable_group["table_column"],
         },
         "artifacts": artifacts,
         "working": {"generated_sql": sql},

--- a/backend/oracle/predict.py
+++ b/backend/oracle/predict.py
@@ -1,7 +1,7 @@
 import os
 import time
 import traceback
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List
 
 from celery.utils.log import get_task_logger
 from prophet import Prophet

--- a/oracle_tests/test_data.json
+++ b/oracle_tests/test_data.json
@@ -13,7 +13,11 @@
       {
         "clarification": "Could you please confirm if the objective is to find at least 5 restaurants that offer a variety of food types based on their food_type?",
         "input_type": "single_choice",
-        "options": ["yes", "no", "Other"],
+        "options": [
+          "yes",
+          "no",
+          "Other"
+        ],
         "answer": "yes"
       },
       {
@@ -46,7 +50,10 @@
     "gather_context": {
       "context": "",
       "objective": "Identify at least 5 restaurants that offer a variety of food types. This can be achieved by fetching data from the restaurant table and aggregating the unique food types available.",
-      "decision_variables": ["restaurant_id", "food_type"],
+      "decision_variables": [
+        "restaurant_id",
+        "food_type"
+      ],
       "constraints": [],
       "problem_statement": "Select at least 5 restaurant IDs that provide a variety of food types without any specific rating or city constraints.",
       "issues": [],
@@ -60,7 +67,7 @@
           "independent_variable_group": {
             "name": "restaurantLocation",
             "description": "The location details of the restaurants",
-            "table.column": [
+            "table_column": [
               "location.restaurant_id",
               "location.city_name",
               "location.street_name",
@@ -84,7 +91,7 @@
           "independent_variable_group": {
             "name": "restaurantGeography",
             "description": "The geographic details of the restaurants",
-            "table.column": [
+            "table_column": [
               "geographic.city_name",
               "geographic.county",
               "geographic.region"
@@ -107,7 +114,7 @@
           "independent_variable_group": {
             "name": "restaurantDetails",
             "description": "The details of the restaurants including name and rating",
-            "table.column": [
+            "table_column": [
               "restaurant.id",
               "restaurant.name",
               "restaurant.rating"
@@ -130,7 +137,7 @@
           "independent_variable_group": {
             "name": "restaurantLocation",
             "description": "The location details of the restaurants",
-            "table.column": [
+            "table_column": [
               "location.restaurant_id",
               "location.city_name",
               "location.street_name",
@@ -174,7 +181,7 @@
           "independent_variable_group": {
             "name": "restaurantGeography",
             "description": "The geographic details of the restaurants",
-            "table.column": [
+            "table_column": [
               "geographic.city_name",
               "geographic.county",
               "geographic.region"
@@ -194,7 +201,10 @@
       ],
       "dependent_variable": {
         "description": "Identify restaurant IDs that provide a variety of food types.",
-        "table.column": ["restaurant.id", "restaurant.food_type"],
+        "table_column": [
+          "restaurant.id",
+          "restaurant.food_type"
+        ],
         "data_available": true
       },
       "summary": ""


### PR DESCRIPTION
Accompanying PR for changes in https://github.com/defog-ai/defog-backend-python/pull/338

# Changes

- Add route `/oracle/get_report_summary` which returns `executive_summary` which would contain a markdown of the executive summary. This is similar to before, except that we now have the links to individual analysis as `[1]`, `[2]`, etc where appropriate. The executive summary would not contain the actual content of each analysis. This route is to be called by the frontend when showing the report, allowing the user to click into each analysis where required.
- Refactor report generation with the right routes, input data, and make both requests for md and summary generation concurrently.
- Refactor `table.column` to `table_column`.

# Testing

Tested end-to-end via the UI, generated this report:

[summary_report.pdf](https://github.com/user-attachments/files/18002766/summary_report.pdf)

Note that `# Executive Summary` is repeated twice because we're showing `mdx` for now.