### PR TITLE
[Oracle] Summary Updates

### DIFF
--- a/backend/oracle/celery_app.py
+++ b/backend/oracle/celery_app.py
@@ -1,8 +1,7 @@
 import os
 from celery import Celery
-from celery.utils.log import get_task_logger
 
-from utils_logging import LOG_LEVEL
+from utils_logging import LOGGER
 
 # Initialize Celery with redis backend
 REDIS_HOST = os.getenv("REDIS_INTERNAL_HOST", "agents-redis")
@@ -22,9 +21,4 @@ celery_app.conf.update(
     enable_utc=True,
 )
 
-# celery requires a different logger object. we can still reuse utils_logging
-# which just assumes a LOGGER object is defined
-LOGGER = get_task_logger(__name__)
-LOGGER.setLevel(LOG_LEVEL)
-
-print(f"Initialized Celery app:\n{celery_app}")
+LOGGER.info(f"Initialized Celery app:\n{celery_app}")

--- a/backend/oracle/export.py
+++ b/backend/oracle/export.py
@@ -1,0 +1,101 @@
+import asyncio
+from typing import Any, Dict, List
+
+from generic_utils import make_request
+from pydantic import BaseModel, ValidationError
+from oracle.constants import DEFOG_BASE_URL, TaskType
+from utils_logging import LOGGER, truncate_obj
+
+
+async def generate_report(
+    api_key: str,
+    report_id: str,
+    task_type: TaskType,
+    inputs: Dict[str, Any],
+    outputs: Dict[str, Any],
+):
+    """
+    This function will generate the final report, by consolidating all the
+    information gathered, explored, predicted, and optimized.
+    """
+    LOGGER.info(f"Exporting for report {report_id}")
+    LOGGER.debug(f"inputs: {inputs}")
+    LOGGER.debug(f"inputs: {outputs}")
+    json_data = {
+        "api_key": api_key,
+        "task_type": task_type.value,
+        "inputs": inputs,
+        "outputs": outputs,
+    }
+
+    # generate the full report markdown and mdx
+    mdx_task = make_request(
+        DEFOG_BASE_URL + "/oracle/generate_report_mdx", json_data, timeout=300
+    )
+    # generate a synthesized executive summary to the report
+    summary_task = make_request(
+        DEFOG_BASE_URL + "/oracle/generate_report_summary",
+        json_data,
+        timeout=300,
+    )
+    responses = await asyncio.gather(mdx_task, summary_task)
+    md = responses[0].get("md")
+    mdx = responses[0].get("mdx")
+    summary_dict = responses[1]
+    if md is None:
+        LOGGER.error("No MD returned from backend.")
+    else:
+        # log truncated markdown for debugging
+        trunc_md = truncate_obj(md, max_len_str=1000, to_str=True)
+        LOGGER.debug(f"MD generated for report {report_id}\n{trunc_md}")
+
+    if not summary_dict or not isinstance(summary_dict, dict):
+        LOGGER.error("No Summary dictionary returned from backend.")
+    else:
+        trunc_summary = truncate_obj(summary_dict, max_len_str=1000, to_str=True)
+        LOGGER.debug(
+            f"Summary dictionary generated for report {report_id}\n{trunc_summary}"
+        )
+        summary_md = summary_dict_to_markdown(summary_dict)
+    return {
+        "md": summary_md + "\n\n" + md,
+        "mdx": summary_md + "\n\n" + mdx,
+        "executive_summary": summary_dict,
+    }
+
+
+class Recommendation(BaseModel):
+    title: str
+    insight: str
+    action: str
+    analysis_reference: List[int]
+
+
+class GenerateReportSummaryResponse(BaseModel):
+    title: str
+    introduction: str
+    recommendations: List[Recommendation]
+
+
+def summary_dict_to_markdown(summary_dict: Dict[str, Any]) -> str:
+    """
+    Converts the summary dictionary to markdown for compatibility with the
+    existing report markdown display.
+    """
+    try:
+        summary = GenerateReportSummaryResponse.model_validate(summary_dict)
+    except ValidationError as e:
+        LOGGER.error(f"Invalid summary dictionary generated: {e}")
+        return ""
+
+    md = f"# {summary.title}\n\n{summary.introduction}\n\n"
+    for recommendation in summary.recommendations:
+        md += f"""## {recommendation.title}
+
+{recommendation.insight}
+
+*Recommendation*
+{recommendation.action}
+
+"""
+    return md


### PR DESCRIPTION
Accompanying changes to https://github.com/defog-ai/defog-backend-python/pull/339
- Remove additional nesting within the `executive_summary` key.
- We use the parsed json object directly, relying on a pydantic model to validate the fields.
- Introduce `summary_dict_to_markdown` for converting the summary dictionary returned into a markdown string for compatibility with the existing markdown report display.
- Shift export / report generation code into a separate file
- Use utils_logging's LOGGER instead of the celery one as it is unnecessarily verbose, for example:
```
2024-12-04 15:42:49 [2024-12-04 07:42:49,154: INFO/MainProcess] Task oracle.core.begin_generation_task[de0daa6e-878b-449b-9c37-031ffae17152] received
```

Tested and generated the following report:

[summary_dict_report.pdf](https://github.com/user-attachments/files/18004455/summary_dict_report.pdf)
