### PR TITLE
Insert DSH instance with Cricket data

### DIFF
--- a/backend/adhoc/insert_user_db_creds.py
+++ b/backend/adhoc/insert_user_db_creds.py
@@ -33,6 +33,10 @@ users = [
         "username": "webshop",
         "password": "test",
     },
+    {
+        "username": "cricket",
+        "password": "test",
+    }
 ]
 databases = [
     {
@@ -59,6 +63,10 @@ databases = [
         "api_key": "test_webshop",
         "database": "webshop",
     },
+    {
+        "api_key": "test_cricket",
+        "database": "cricket",
+    }
 ]
 DB_CREDS = {
     "host": "host.docker.internal",


### PR DESCRIPTION
This PR is the third and last step of adding a new database for testing and making it easily sharable among team members without any extra setup adhoc:

Kindly run this for the change to affect your database:
`$ docker exec -it defog-self-hosted-agents-python-server-1 /bin/bash -c "python adhoc/insert_user_db_creds.py"`