### PR TITLE
[Oracle] Fix Edge Case

### DIFF
--- a/backend/oracle/export.py
+++ b/backend/oracle/export.py
@@ -41,15 +41,15 @@ async def generate_report(
     responses = await asyncio.gather(mdx_task, summary_task)
     md = responses[0].get("md")
     mdx = responses[0].get("mdx")
-    analyses_mdx = responses[0].get("analyses_mdx")
+    analyses_mdx = responses[0].get("analyses_mdx", "")
 
     LOGGER.info(f"Generated MDX for report {report_id}")
 
     summary_response = responses[1]
 
-    summary_dict = summary_response.get("summary_dict")
-    summary_md = summary_response.get("summary_md")
-    summary_mdx = summary_response.get("summary_mdx")
+    summary_dict = summary_response.get("summary_dict", {})
+    summary_md = summary_response.get("summary_md", "")
+    summary_mdx = summary_response.get("summary_mdx", "")
 
     # log the md and summary
     if md is None:


### PR DESCRIPTION
Fix edge case where if md/mdx/analysis_mdx was `None`, the string concatenation would fail like so:
```
2024-12-05 10:02:25 ERROR: Error occurred in stage TaskStage.EXPORT:
2024-12-05 10:02:25 can only concatenate str (not "NoneType") to str
2024-12-05 10:02:25 ERROR: Traceback (most recent call last):
2024-12-05 10:02:25   File "/backend/oracle/core.py", line 86, in begin_generation_async_task
2024-12-05 10:02:25     stage_result = await execute_stage(
2024-12-05 10:02:25                    ^^^^^^^^^^^^^^^^^^^^
2024-12-05 10:02:25   File "/backend/oracle/core.py", line 197, in execute_stage
2024-12-05 10:02:25     stage_result = await generate_report(
2024-12-05 10:02:25                    ^^^^^^^^^^^^^^^^^^^^^^
2024-12-05 10:02:25   File "/backend/oracle/export.py", line 70, in generate_report
2024-12-05 10:02:25     "md": summary_md + "\n\n" + md,
2024-12-05 10:02:25           ~~~~~~~~~~~~~~~~~~~~^~~~
2024-12-05 10:02:25 TypeError: can only concatenate str (not "NoneType") to str
```

We add default string/dict values