### PR TITLE
[Oracle] Polling Fix

### DIFF
--- a/frontend/pages/oracle-frontend.js
+++ b/frontend/pages/oracle-frontend.js
@@ -233,16 +233,21 @@ function OracleDashboard() {
   }, []);
 
   useEffect(() => {
-    const fetchInitialReports = async () => {
-      await fetchReports(apiKeyName, setReports);
-    };
-
-    // Fetch reports once when the page loads
-    fetchInitialReports();
-  }, [apiKeyName]);
-
-  useEffect(() => {
     let intervalId;
+
+    // fetch initial reports
+    const fetchInitial = async () => {
+      const reports = await fetchReports(apiKeyName, setReports);
+      if (reports) {
+        const allTerminal = reports.every(
+          (report) => report.status === "done" || report.status === "error"
+        );
+        if (!allTerminal) {
+          setIsPolling(true);
+        }
+      }
+    };
+    fetchInitial();
 
     const pollReports = async () => {
       const reports = await fetchReports(apiKeyName, setReports);


### PR DESCRIPTION
# Problem

Discovered a subtle bug when I was working on analysis_eval and triggering the report generation via api. Previously, when I refreshed the page, the frontend would not poll for reports' status if any of the current reports are not in a terminal state (e.g. `done` or `error`). This is confusing because if the user accidentally or unintentionally refreshed the page after kicking off a generation, the list of reports would be completely static and not update the status after the report has finished.

Demo of the problem in this loom video:
https://www.loom.com/share/a49fffd5461c4c42a6be334711bd5447?sid=f9e26343-d1ad-4be5-875e-ebec9ce219ec

# Fix

I'm not sure if this is the best way to do it, but I've combined the 2 functions for fetching reports into a single `useEffect` scope, so as to share the state for the interval setting, and also because they both share the same set of dependencies. Not sure what edge cases there might be, so please feel free to point out!

Tested and works in this loom video:
https://www.loom.com/share/aec60a0a6ebe46c08ba3647d953b0d87?sid=6c683175-f783-4b9d-8959-2fb35ca32652
