### PR TITLE
Improve Clarifications Section of the Oracle

### DIFF
--- a/frontend/pages/oracle-frontend.js
+++ b/frontend/pages/oracle-frontend.js
@@ -552,6 +552,21 @@ function OracleDashboard() {
     }
   };
 
+  const deleteClarification = (index, clarificationObject) => {
+    // Remove from answered clarifications if it exists there
+    setAnsweredClarifications((prev) =>
+      prev.filter((c) => c.clarification !== clarificationObject.clarification)
+    );
+
+    // Remove from unanswered clarifications if it exists there
+    setUnansweredClarifications((prev) =>
+      prev.filter((c) => c.clarification !== clarificationObject.clarification)
+    );
+
+    // Remove from answers
+    delete answers.current[clarificationObject.clarification];
+  };
+
   return (
     <>
       <Meta />
@@ -606,12 +621,16 @@ function OracleDashboard() {
               <button
                 onClick={handleSendClick}
                 disabled={!userQuestion.trim() || userQuestion.length < 5}
-                className={`flex items-center justify-center p-2 rounded-full transition-colors duration-200 ${
+                className={`flex items-center justify-center p-2 rounded-full ${
                   userQuestion.trim() && userQuestion.length >= 5
-                    ? "text-purple-600 hover:text-purple-900 dark:text-purple-400 dark:hover:text-purple-300"
+                    ? "text-purple-600 hover:text-purple-800 dark:text-purple-300 dark:hover:text-purple-200 bg-purple-50 dark:bg-purple-900/30 hover:bg-purple-100 dark:hover:bg-purple-900/40"
                     : "text-gray-400 dark:text-gray-600 cursor-not-allowed"
                 }`}
-                title="Send question"
+                title={
+                  !userQuestion.trim() || userQuestion.length < 5
+                    ? "Type at least 5 characters"
+                    : "Send question to get clarifications"
+                }
               >
                 <SendOutlined className="text-lg" />
               </button>
@@ -722,9 +741,18 @@ function OracleDashboard() {
           </div>
 
           <Button
-            className="bg-purple-500 text-white py-4 px-4 mt-2 mb-2 rounded-lg hover:bg-purple-600 disabled:bg-gray-300 dark:disabled:bg-gray-700 dark:hover:bg-purple-700"
+            className={`py-4 px-6 mt-2 mb-2 rounded-lg ${
+              answeredClarifications.length > 0 || unansweredClarifications.length > 0
+                ? "bg-purple-500 text-white hover:bg-purple-600"
+                : "bg-gray-200 text-gray-400 dark:bg-gray-800 dark:text-gray-600 cursor-not-allowed"
+            }`}
             onClick={generateReport}
-            disabled={userQuestion.length < 5 || taskType === ""}
+            disabled={userQuestion.length < 5 || taskType === "" || (answeredClarifications.length === 0 && unansweredClarifications.length === 0)}
+            title={
+              answeredClarifications.length > 0 || unansweredClarifications.length > 0
+                ? "Generate report"
+                : "First send your question to get clarifications"
+            }
           >
             Generate
           </Button>


### PR DESCRIPTION
The PR does the following:
Additional Comments section at the end of the clarifications! This is sent to the backend as "Additional Comments" in the same object format as other clarifications. Verification that this goes for processing:
```
2024-12-26 07:52:26   "api_key": "test_cricket",
2024-12-26 07:52:26   "user_question": "compare india vs pakistan teams",
2024-12-26 07:52:26   "task_type": "exploration",
2024-12-26 07:52:26   "sources": [],
2024-12-26 07:52:26   "clarifications": [
2024-12-26 07:52:26     {
2024-12-26 07:52:26       "clarification": "What specific aspects of the India vs Pakistan teams are you interested in comparing? (e.g., runs scored, wickets taken, player performance)",
2024-12-26 07:52:26       "answer": "runs scored"
2024-12-26 07:52:26     },
2024-12-26 07:52:26     {
2024-12-26 07:52:26       "clarification": "Additional Comments",
2024-12-26 07:52:26       "answer": "When I ask you to analyze Pakistan's performance against India I also want you to look at the matches each of the teams played against other teams to see who did well overall in the world cup not just the natch they played against each other!"
2024-12-26 07:52:26     }
2024-12-26 07:52:26   ]

```
<img width="1149" alt="Screenshot 2024-12-26 at 7 50 47 AM" src="https://github.com/user-attachments/assets/33d64b47-1507-461d-b815-3a094d44ad0e" />


We draw a distinction between answered vs unanswered clarification questions with labels and make sure we do not delete the answered ones unless the main question changes in which case we just retrigger the `clarify_question/` endpoint altogether. 

## Display Changes
1. **Prioritized Display Order**
   - Answered clarifications automatically move to the top of the list
   - Maintains visual hierarchy and helps users track their progress

2. **Debounced Text Input Handling**
   - For text area inputs, UI updates are intentionally delayed
   - Waits for user to pause typing (1 second) before moving the clarification
   - Prevents distracting UI jumps during active typing
   - Improves user experience by allowing uninterrupted text entry


Keeping macmillan's feedback in mind, we make the following change:
1. **Initial Question Entry**
   - Users can take their time composing their first question
   - No automatic triggers or interruptions
   - Manual submission via Send button required
   - Gives users control over when to start the clarification process

2. **Subsequent Question Edits**
   - Automatic clarification updates trigger after edits
   - 1-second debounce as before
   - deletes clarifications altogether and triggers new ones

We disable generate button to make sure user follows the steps especially the first time i.e. write question, click send to generate clarifications and then generate!

Please let me know if this is not a desired UX and very happy to change!