### PR TITLE
Fixed a bug where a new oracle report would sometimes be stuck on "Started"

### DIFF
--- a/backend/oracle_routes.py
+++ b/backend/oracle_routes.py
@@ -45,6 +45,7 @@ from oracle.redis_utils import (
     store_analysis_task_id,
 )
 from oracle.celery_app import celery_app
+from oracle.core import generate_analysis_task
 
 
 router = APIRouter()
@@ -426,8 +427,6 @@ async def generate_analysis(req: GenerateAnalysis):
     LOGGER.debug(f"Summary dict updated for report {req.report_id}")
 
     # Start the Celery task
-    from oracle.core import generate_analysis_task
-
     task = generate_analysis_task.delay(
         api_key=api_key,
         report_id=int(req.report_id),


### PR DESCRIPTION
Here's a demo of what used to happen. A report would sometimes (but not always) forever stay stuck on "Started"

![image](https://github.com/user-attachments/assets/ae89bee3-4718-4453-a2f5-55815fa813a4)

This was the error in the console backend. Which, again, was _very_ strange. Because it would sometimes work and sometimes now work 🤔 

```bash
backend        | [2025-01-23 18:54:07,156: ERROR/MainProcess] Received unregistered task of type 'oracle.core.begin_generation_task'.
backend        | The message has been ignored and discarded.
```

Turns out, the problem was with the way we were importing the `generate_analysis_task`. It was being imported from inside a function, instead of at the top level. This - for complicated reasons - made it difficult for the celery app to "discover" this task.

More details in this ChatGPT conversation! https://chatgpt.com/share/e/67934659-aa1c-8007-ae44-1a1c30b329ef