### PR TITLE
Adhoc OAuth

### DIFF
--- a/backend/adhoc/README.md
+++ b/backend/adhoc/README.md
@@ -2,6 +2,21 @@
 
 You can use these scripts for inserting / initializing your DSH instance with user data.
 
+## OAuth Accounts
+
+If you would like to give admin access to your Google account, you can add your email as a dictionary inside the `users` list in the `insert_user_db_creds.py` file.
+
+No password is needed for Google accounts if we're using OAuth.
+
+```python
+users = [
+    ...
+    {
+        "username": "jp@defog.ai", # no password needed
+    },
+]
+```
+
 ## Insert User DB Creds
 
 You can start by adding the following api_key's and key names to your `.env` file like below:
@@ -16,3 +31,5 @@ This script inserts multiple test user and db creds data into the database, so t
 ```sh
 $ docker exec -it defog-self-hosted-agents-python-server-1 /bin/bash -c "python adhoc/insert_user_db_creds.py"
 ```
+
+This script is idempotent, so it can be run multiple times without any issues. We will update the existing users and db creds if they already exist, instead of throwing an error or creating duplicates.

--- a/backend/adhoc/insert_user_db_creds.py
+++ b/backend/adhoc/insert_user_db_creds.py
@@ -3,6 +3,7 @@ import datetime
 import hashlib
 import os
 
+from auth_utils import get_hashed_username
 from db_utils import DbCreds, Users
 from sqlalchemy import create_engine, insert, select, update
 
@@ -37,6 +38,9 @@ users = [
     {
         "username": "cricket",
         "password": "test",
+    },
+    {
+        "username": "jp@defog.ai",
     },
 ]
 databases = [
@@ -98,8 +102,11 @@ with engine.begin() as conn:
     # insert users and their db_creds
     for user in users:
         username = user["username"]
-        password = user["password"]
-        hashed_password = get_hashed_password(username, password)
+        password = user.get("password")
+        if password:
+            hashed_password = get_hashed_password(username, password)
+        else:
+            hashed_password = get_hashed_username(username)
 
         # check if user exists and update
         user_result = conn.execute(


### PR DESCRIPTION
Motivation: To allow us to to quickly add OAuth users (e.g. for local testing), we can add entries in the `users` list in `adhoc/insert_user_db_creds.py` so that we don't have to login via the admin user and create those users manually via the UI. This helps speed up setup.