### PR TITLE
add tiptap related deps

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,10 @@
     "@defogdotai/agents-ui-components": "1.1.46",
     "@notionhq/client": "^2.2.14",
     "@react-oauth/google": "^0.12.1",
+    "@sereneinserenade/tiptap-comment-extension": "^0.1.2",
+    "@tiptap/core": "^2.11.5",
+    "@tiptap/react": "^2.11.5",
+    "@tiptap/starter-kit": "^2.11.5",
     "@types/react-dom": "19.0.0",
     "@uiw/react-codemirror": "^4.23.7",
     "antd": "^5.22.5",
@@ -32,7 +36,8 @@
     "react-fast-marquee": "^1.6.2",
     "recharts": "^2.15.0",
     "sass": "^1.69.7",
-    "tailwind-merge": "^2.3.0"
+    "tailwind-merge": "^2.3.0",
+    "tiptap-markdown": "^0.8.10"
   },
   "devDependencies": {
     "@next/bundle-analyzer": "15.1.1",


### PR DESCRIPTION
`pnpm export` was failing for me earlier, with messages like this:
```
$ pnpm export                                        

> defog-self-hosted@0.1.0 export /Users/jp/workspace/defog-self-hosted/frontend
> sh ./rename_env.sh 1 && next build && sh ./export.sh && sh ./rename_env.sh 2

renaming .env.local to .env.local.backup
 ⚠ The "experimental.esmExternals" option has been modified. experimental.esmExternals is not recommended to be modified as it may disrupt module resolution. It should be removed from your next.config.mjs.
   ▲ Next.js 15.1.1
   - Experiments (use with caution):
     · esmExternals

   Linting and checking validity of types  ...Failed to compile.

./components/oracle/reports/comments/OracleCommentHandler.tsx:11:8
Type error: Cannot find module '@tiptap/react' or its corresponding type declarations.

   9 |   ReactNodeViewRenderer,
  10 |   useCurrentEditor,
> 11 | } from "@tiptap/react";
     |        ^
  12 | import { OracleReportContext } from "../../OracleReportContext";
  13 | import { MessageSquarePlus } from "lucide-react";
  14 | import type { CommentManager } from "$components/oracle/oracleUtils";
 ELIFECYCLE  Command failed with exit code 1.
```

Had to add these deps 1-by-1 via pnpm, for example, `pnpm add @tiptap/react` (which modified the `package.json`), to get it to build successfully. Not sure if this is the right way to fix it - please let me know if this is the wrong hack!