### PR TITLE
Oracle new analysis generation fixes

### DIFF
--- a/backend/db_oracle_utils.py
+++ b/backend/db_oracle_utils.py
@@ -1,37 +1,35 @@
-from typing import Dict, List, Tuple
+from typing import Dict, List
 from sqlalchemy import select, update, delete
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm.attributes import flag_modified
+from oracle.constants import TaskStage
 from db_models import (
-    OracleReports, OracleAnalyses, OracleSources,
-    ImportedTables, OracleGuidelines
+    OracleReports,
+    OracleAnalyses,
 )
 from db_config import engine
 from utils_logging import LOGGER
 
+
 async def update_status(report_id: int, new_status: str):
     """Update the status of a report."""
     async with AsyncSession(engine) as session:
-        try:
+        async with session.begin():
             await session.execute(
                 update(OracleReports)
                 .where(OracleReports.report_id == report_id)
                 .values(status=new_status)
             )
-            await session.commit()
-        except Exception as e:
-            LOGGER.error(f"Error updating report status: {e}")
-            await session.rollback()
-            raise
+
 
 async def get_report_data(report_id: int, api_key: str) -> Dict:
     """Get report data from the database."""
     async with AsyncSession(engine) as session:
-        try:
+        async with session.begin():
             result = await session.execute(
-                select(OracleReports)
-                .where(
+                select(OracleReports).where(
                     OracleReports.report_id == report_id,
-                    OracleReports.api_key == api_key
+                    OracleReports.api_key == api_key,
                 )
             )
             row = result.first()
@@ -41,34 +39,30 @@ async def get_report_data(report_id: int, api_key: str) -> Dict:
                 "report_id": row[0].report_id,
                 "report_name": row[0].report_name,
                 "status": row[0].status,
-                "created_ts": row[0].created_ts.isoformat() if row[0].created_ts else None,
+                "created_ts": (
+                    row[0].created_ts.isoformat() if row[0].created_ts else None
+                ),
                 "api_key": row[0].api_key,
                 "username": row[0].username,
                 "inputs": row[0].inputs,
                 "outputs": row[0].outputs,
                 "feedback": row[0].feedback,
-                "comments": row[0].comments
+                "comments": row[0].comments,
             }
-        except Exception as e:
-            LOGGER.error(f"Error getting report data: {e}")
-            raise
+
 
 async def delete_analysis(api_key: str, analysis_id: str, report_id: int):
     """Delete an analysis from the database."""
     async with AsyncSession(engine) as session:
-        try:
+        async with session.begin():
             await session.execute(
                 delete(OracleAnalyses).where(
                     OracleAnalyses.api_key == api_key,
                     OracleAnalyses.analysis_id == analysis_id,
-                    OracleAnalyses.report_id == report_id
+                    OracleAnalyses.report_id == report_id,
                 )
             )
-            await session.commit()
-        except Exception as e:
-            LOGGER.error(f"Error deleting analysis: {e}")
-            await session.rollback()
-            raise
+
 
 async def add_or_update_analysis(
     api_key: str,
@@ -76,33 +70,29 @@ async def add_or_update_analysis(
     report_id: int,
     analysis_json: Dict,
     status: str = "pending",
-    mdx: str = None
+    mdx: str = None,
 ):
     """Add or update an analysis in the database."""
     async with AsyncSession(engine) as session:
-        try:
+        async with session.begin():
             result = await session.execute(
                 select(OracleAnalyses).where(
                     OracleAnalyses.api_key == api_key,
                     OracleAnalyses.analysis_id == analysis_id,
-                    OracleAnalyses.report_id == report_id
+                    OracleAnalyses.report_id == report_id,
                 )
             )
             existing_analysis = result.first()
-            
+
             if existing_analysis:
                 await session.execute(
                     update(OracleAnalyses)
                     .where(
                         OracleAnalyses.api_key == api_key,
                         OracleAnalyses.analysis_id == analysis_id,
-                        OracleAnalyses.report_id == report_id
+                        OracleAnalyses.report_id == report_id,
                     )
-                    .values(
-                        analysis_json=analysis_json,
-                        status=status,
-                        mdx=mdx
-                    )
+                    .values(analysis_json=analysis_json, status=status, mdx=mdx)
                 )
             else:
                 new_analysis = OracleAnalyses(
@@ -111,125 +101,102 @@ async def add_or_update_analysis(
                     report_id=report_id,
                     analysis_json=analysis_json,
                     status=status,
-                    mdx=mdx
+                    mdx=mdx,
                 )
                 session.add(new_analysis)
-            
-            await session.commit()
-        except Exception as e:
-            LOGGER.error(f"Error adding/updating analysis: {e}")
-            await session.rollback()
-            raise
+
 
 async def get_analysis_status(api_key: str, analysis_id: str, report_id: int) -> str:
     """Get the status of an analysis."""
     async with AsyncSession(engine) as session:
-        try:
+        async with session.begin():
             result = await session.execute(
                 select(OracleAnalyses.status).where(
                     OracleAnalyses.api_key == api_key,
                     OracleAnalyses.analysis_id == analysis_id,
-                    OracleAnalyses.report_id == report_id
+                    OracleAnalyses.report_id == report_id,
                 )
             )
             row = result.first()
             status = row[0] if row else None
             return None, status
-        except Exception as e:
-            LOGGER.error(f"Error getting analysis status: {e}")
-            return str(e), None
+
 
 async def update_analysis_status(
-    api_key: str,
-    analysis_id: str,
-    report_id: int,
-    new_status: str
+    api_key: str, analysis_id: str, report_id: int, new_status: str
 ):
     """Update the status of an analysis."""
     async with AsyncSession(engine) as session:
-        try:
+        async with session.begin():
             result = await session.execute(
                 update(OracleAnalyses)
                 .where(
                     OracleAnalyses.api_key == api_key,
                     OracleAnalyses.analysis_id == analysis_id,
-                    OracleAnalyses.report_id == report_id
+                    OracleAnalyses.report_id == report_id,
                 )
                 .values(status=new_status)
             )
             if result.rowcount == 0:
                 raise Exception("Analysis not found")
-            await session.commit()
-        except Exception as e:
-            LOGGER.error(f"Error updating analysis status: {e}")
-            await session.rollback()
-            raise
+
 
 async def update_summary_dict(api_key: str, report_id: int, summary_dict: Dict):
     """Update the summary dictionary and optionally the report name."""
     async with AsyncSession(engine) as session:
-        try:
+        async with session.begin():
             report = await session.execute(
                 select(OracleReports).where(
                     OracleReports.report_id == report_id,
-                    OracleReports.api_key == api_key
+                    OracleReports.api_key == api_key,
                 )
             )
             report = report.first()
             if not report:
                 raise Exception("Report not found")
-            
+
             report = report[0]
             current_outputs = report.outputs or {}
-            current_outputs["summary_dict"] = summary_dict
-            
+
+            current_outputs[TaskStage.EXPORT.value]["executive_summary"] = summary_dict
+
             update_dict = {"outputs": current_outputs}
             if "title" in summary_dict:
                 update_dict["report_name"] = summary_dict["title"]
-            
+
+            flag_modified(report, "outputs")
+            flag_modified(report, "report_name")
             await session.execute(
                 update(OracleReports)
                 .where(
                     OracleReports.report_id == report_id,
-                    OracleReports.api_key == api_key
+                    OracleReports.api_key == api_key,
                 )
                 .values(**update_dict)
             )
-            await session.commit()
-        except Exception as e:
-            LOGGER.error(f"Error updating summary dict: {e}")
-            await session.rollback()
-            raise
+
 
 async def update_report_name(report_id: int, report_name: str):
     """Update the name of a report."""
     async with AsyncSession(engine) as session:
-        try:
+        async with session.begin():
             await session.execute(
                 update(OracleReports)
                 .where(OracleReports.report_id == report_id)
                 .values(report_name=report_name)
             )
-            await session.commit()
-        except Exception as e:
-            LOGGER.error(f"Error updating report name: {e}")
-            await session.rollback()
-            raise
+
 
 async def get_multiple_analyses(
-    analysis_ids: List[str] = [],
-    columns: List[str] = ["analysis_id", "user_question"]
+    analysis_ids: List[str] = [], columns: List[str] = ["analysis_id", "user_question"]
 ) -> List[Dict]:
     """Get multiple analyses from the database."""
     async with AsyncSession(engine) as session:
-        try:
-            query = select(*[getattr(Analyses, col) for col in columns])
+        async with session.begin():
+            query = select(*[getattr(OracleAnalyses, col) for col in columns])
             if analysis_ids:
-                query = query.where(Analyses.analysis_id.in_(analysis_ids))
-            
+                query = query.where(OracleAnalyses.analysis_id.in_(analysis_ids))
+
             result = await session.execute(query)
             rows = result.all()
             return None, [dict(zip(columns, row)) for row in rows]
-        except Exception as e:
-            LOGGER.error(f"Error getting multiple analyses: {e}")
-            return str(e), None

--- a/backend/generic_utils.py
+++ b/backend/generic_utils.py
@@ -19,7 +19,8 @@ if not DEFOG_API_KEYS:
 DEFOG_API_KEY_NAMES = os.environ.get("DEFOG_API_KEY_NAMES")
 
 
-async def make_request(url, data, timeout=180):
+async def make_request(url, data, timeout=180, log_time=False):
+    start_time = datetime.now()
     if LOG_LEVEL == "DEBUG":
         LOGGER.debug(f"Making request to: {url}")
         # avoid excessively long logs (e.g. for base64 encoded images)
@@ -34,6 +35,11 @@ async def make_request(url, data, timeout=180):
         )
     response = r.json()
     response_str = truncate_obj(response)
+    if log_time:
+        LOGGER.info(
+            f"Request to {url} took: {(datetime.now() - start_time).total_seconds()}s"
+        )
+
     if r.status_code != 200:
         LOGGER.error(f"Error in request:\n{response_str}")
         return response

--- a/backend/oracle/core.py
+++ b/backend/oracle/core.py
@@ -85,7 +85,9 @@ async def begin_generation_async_task(
             async with AsyncSession(engine) as session:
                 async with session.begin():
                     # update status of the report
-                    stmt = select(OracleReports).where(OracleReports.report_id == report_id)
+                    stmt = select(OracleReports).where(
+                        OracleReports.report_id == report_id
+                    )
                     result = await session.execute(stmt)
                     report = result.scalar_one()
                     # we want to add some sort of indicator to a revision report
@@ -106,7 +108,7 @@ async def begin_generation_async_task(
                         original_report.status = (
                             "Revision in progress: " + STAGE_TO_STATUS[stage]
                         )
-            
+
             stage_result = await execute_stage(
                 api_key=api_key,
                 report_id=report_id,
@@ -119,7 +121,9 @@ async def begin_generation_async_task(
             # update the status and current outputs of the report generation
             async with AsyncSession(engine) as session:
                 async with session.begin():
-                    stmt = select(OracleReports).where(OracleReports.report_id == report_id)
+                    stmt = select(OracleReports).where(
+                        OracleReports.report_id == report_id
+                    )
                     result = await session.execute(stmt)
                     report = result.scalar_one()
                     report.status = (
@@ -145,10 +149,14 @@ async def begin_generation_async_task(
             # update the status of the report
             async with AsyncSession(engine) as session:
                 async with session.begin():
-                    stmt = select(OracleReports).where(OracleReports.report_id == report_id)
+                    stmt = select(OracleReports).where(
+                        OracleReports.report_id == report_id
+                    )
                     result = await session.execute(stmt)
                     report = result.scalar_one()
-                    outputs[stage.value] = {"error": str(e) + "\n" + traceback.format_exc()}
+                    outputs[stage.value] = {
+                        "error": str(e) + "\n" + traceback.format_exc()
+                    }
                     report.outputs = outputs
                     report.status = "error"
                     # if this is is_revision, then just delete this report
@@ -289,8 +297,6 @@ def generate_analysis_task(
                 delete_analysis_task_id(analysis_id)
                 return {"error": report_data["error"]}
 
-            report_data = report_data["data"]
-
             # Call explore_data with a single analysis request
             inputs = {
                 "user_question": new_analysis_question,
@@ -376,6 +382,7 @@ def generate_analysis_task(
                     "skip_rephrase": True,
                     "table_last": True,
                 },
+                log_time=True,
             )
 
             mdx = res["mdx"]

--- a/backend/oracle/utils_explore_data.py
+++ b/backend/oracle/utils_explore_data.py
@@ -40,6 +40,7 @@ async def gen_sql(
             "glossary": glossary,
             "hard_filters": hard_filters,
         },
+        log_time=True,
     )
     # anything that returns a status code other than 200 will return None
     if resp:
@@ -68,6 +69,7 @@ async def retry_sql_gen(
     response = await make_request(
         f"{DEFOG_BASE_URL}/retry_query_after_error",
         data=json_data,
+        log_time=True,
     )
     if response:
         new_query = response["new_query"]

--- a/backend/oracle_routes.py
+++ b/backend/oracle_routes.py
@@ -439,7 +439,6 @@ async def delete_analysis_endpoint(req: AnalysisRequest):
     if req.recommendation_idx is not None:
         summary_dict = (
             (await get_report_data(req.report_id, api_key))
-            .get("data", {})
             .get("outputs", {})
             .get(TaskStage.EXPORT.value, {})
             .get("executive_summary", None)
@@ -499,8 +498,6 @@ async def generate_analysis(req: GenerateAnalysis):
 
     if "error" in report_data:
         return JSONResponse(status_code=404, content=report_data)
-
-    report_data = report_data["data"]
 
     # Get previous analyses data
     err, previous_analyses = await get_multiple_analyses(


### PR DESCRIPTION
Corresponding DBP work: https://github.com/defog-ai/defog-backend-python/pull/404

1. fix summary dict update. wonder how tf this was ever working?!
2. fix async sessions in db oracle utils. **still getting that "another operation is in progress" error though.** But it seems to only happen the server restarts. probably Bad cleanup somehow? Will keep debugging.
3. add a `log_time` param to `make_request` which logs the time taken for that request. Set it to true for oracle calls while I optimise new analysis generation.