### PR TITLE
Preventing multiple race condition-ey creations of the temp/imported dbs inside get_db_engine() when starting up

### DIFF
--- a/backend/auth_utils.py
+++ b/backend/auth_utils.py
@@ -13,6 +13,18 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from utils_logging import LOGGER
 
+
+################################################################################
+# All imports from db_config in this file are inside respective functions.
+# This is to prevent a race condition inside startup.py because this file is imported there.
+# Because of the auth_utils import in startup.py, and a top level db_config import in this file
+# There would be two simultaneous calls to `CREATE DATABASE` inside the `get_db_engine` function in `db_config.py`.
+# The two calls would cause a race condition in `get_db_engine` where the database would not be found in an `exists` check
+# but by the time the following statements were run, the _other_ call to CREATE DATABASE would have completed.
+# Causing a duplicate key error.
+# Also detailed here: https://github.com/defog-ai/defog-self-hosted/pull/385
+################################################################################
+
 SALT = os.getenv("SALT", "default_salt")
 if SALT == "default_salt":
     LOGGER.info(

--- a/backend/startup.py
+++ b/backend/startup.py
@@ -51,6 +51,8 @@ async def init_db(engine: AsyncEngine, imported_tables_engine: Engine | None):
 async def create_admin_user():
     """Create admin user if it doesn't exist"""
     from db_config import engine
+
+    # auth_utils imported inside here to prevent a race condition because of multiple calls to get_db_engine
     from auth_utils import get_hashed_password, login_user
 
     admin_username = os.environ.get("ADMIN_USERNAME", "admin")


### PR DESCRIPTION
This happens on a fresh build.

The `auth_utils` import inside `startup.py` would trigger the `get_db_engine` function, and so would the `lifespan` function.

This caused duplicated `CREATE DATABASE` calls for imported/temp dbs.

The problem was that there was some race condition, where [this](https://github.com/defog-ai/defog-self-hosted/blob/235e86de4a2cc1e1de8444958e87e98164d0acef/backend/db_config.py#L74-L80) `exists` check would be false outside the if, and by the time it goes inside the if, the _other_ `CREATE DATABASE` call would be flushed to the postgres, leading to a duplicate key error:
```
File "/backend/instructions_routes.py", line 1, in <module>
2025-02-17 12:10:33   File "/backend/auth_utils.py", line 6, in <module>
2025-02-17 12:10:33     from db_config import engine
2025-02-17 12:10:33   File "/backend/db_config.py", line 164, in <module>
2025-02-17 12:10:33     engine, imported_tables_engine, temp_tables_engine = get_db_engine()
2025-02-17 12:10:33                                                          ^^^^^^^^^^^^^^^
2025-02-17 12:10:33   File "/backend/db_config.py", line 79, in get_db_engine
psycopg2.errors.UniqueViolation: duplicate key value violates unique constraint "pg_database_datname_index"
2025-02-17 12:10:33 DETAIL:  Key (datname)=(imported_tables) already exists.
```

To solve this:
1. Moved all imports from `db_config` to be inside the functions in `auth_utils`.
2. Moved auth_utils import in startup to inside the `create_admin_user` function.

Tested on fresh build and works fine for me now without any errors.