### PR TITLE
uv instead of pip

### DIFF
--- a/dockerfile.agents-python-server
+++ b/dockerfile.agents-python-server
@@ -5,10 +5,14 @@ WORKDIR /backend
 
 RUN apt-get update && apt-get install -y python3-pip
 
+# Install uv
+RUN pip install uv
+
 COPY ./backend/requirements.txt /root/requirements.txt
 
-RUN pip install --upgrade pip setuptools && \
-  pip install -r /root/requirements.txt
+# Use uv to install dependencies system-wide
+RUN uv pip install --system --upgrade setuptools && \
+    uv pip install --system -r /root/requirements.txt
 
 # expose python server port
 EXPOSE 1235


### PR DESCRIPTION
[UV](https://docs.astral.sh/uv/) is a blazingly fast package manager that's a drop-in replacement for pip. Implemented in rust, and has all the latest best practices wrt dependency management. 

Dep conflicts have much more readable messages, eg:
```
❯ uv add httpie==2
  × No solution found when resolving dependencies for split (python_full_version >= '3.10'):
  ╰─▶ Because httpie==2.0.0 depends on requests>=2.22.0 and your project depends on httpie==2, we can conclude that your project depends on requests>=2.22.0.
      And because your project depends on requests==1, we can conclude that your project's requirements are unsatisfiable.
  help: If you want to add the package regardless of the failed resolution, provide the `--frozen` flag to skip locking and syncing.
```

We test with `docker compose down && docker compose up -d --build`

Before (pip install takes ~42s, end to end takes ~73s):
```
[+] Building 73.8s (28/28) FINISHED                               docker-container:jolly_cartwright
 => [agents-python-server internal] load build definition from dockerfile.agents-python-serve  0.0s
 => => transferring dockerfile: 1.26kB                                                         0.0s
 => [agents-python-server internal] load metadata for docker.io/library/python:3.12-slim       1.6s
 => [agents-python-server auth] library/python:pull token for registry-1.docker.io             0.0s
 => [agents-python-server internal] load .dockerignore                                         0.0s
 => => transferring context: 91B                                                               0.0s
 => [agents-python-server  1/10] FROM docker.io/library/python:3.12-slim@sha256:34656cd904563  0.0s
 => => resolve docker.io/library/python:3.12-slim@sha256:34656cd90456349040784165b9decccbcee4  0.0s
 => [agents-python-server internal] load build context                                         0.0s
 => => transferring context: 721B                                                              0.0s
 => CACHED [agents-python-server  2/10] WORKDIR /backend                                       0.0s
 => CACHED [agents-python-server  3/10] RUN apt-get update && apt-get install -y python3-pip   0.0s
 => CACHED [agents-python-server  4/10] COPY ./backend/requirements.txt /root/requirements.tx  0.0s
 => [agents-python-server  5/10] RUN pip install --upgrade pip setuptools &&   pip install -  42.1s
 => [agents-python-server  6/10] RUN touch /agent-logs-out                                     0.1s 
 => [agents-python-server  7/10] RUN apt-get update && apt-get install -y --no-install-recomm  1.6s
 => [agents-python-server  8/10] RUN curl https://packages.microsoft.com/keys/microsoft.asc |  0.5s
 => [agents-python-server  9/10] RUN apt-get update && apt-get install -y --no-install-recomm  2.2s
 => [agents-python-server 10/10] RUN apt-get clean && rm -rf /var/lib/apt/lists/*              0.0s
 => [agents-python-server] exporting to docker image format                                   23.6s
 => => exporting layers                                                                       13.3s
 => => exporting manifest sha256:6a6ac233cbbff56f4e1db6ae5be3d5201dc65226ab309489c83d3a1bd04d  0.0s
 => => exporting config sha256:c61a23a97d5b2f0ee577b6827a8cf5b988efd77dffa9b9a3f4fde755d62cd0  0.0s
 => => sending tarball                                                                        10.3s
 => [agents-python-server] importing to docker                                                 6.1s
 => => loading layer 353fbf41f7bc 457B / 457B                                                  6.1s
 => => loading layer 8a4fba65685b 274.63MB / 310.31MB                                          6.0s
 => => loading layer c0c8c14b91de 102B / 102B                                                  0.1s
 => => loading layer e3757aa6c0ed 32.77kB / 2.03MB                                             0.1s
 => => loading layer 32fbb5096012 971B / 971B                                                  0.1s
 => => loading layer 0947bcd232a7 32.77kB / 2.10MB                                             0.1s
 => => loading layer efd07d3bb528 500B / 500B                                                  0.0s
 => [agents-python-server] resolving provenance for metadata file                              0.0s
 => [agents-nginx internal] load build definition from dockerfile.agents-nginx                 0.0s
 => => transferring dockerfile: 594B                                                           0.0s
 => [agents-nginx internal] load metadata for docker.io/library/nginx:latest                   1.0s
 => [agents-nginx internal] load .dockerignore                                                 0.0s
 => => transferring context: 91B                                                               0.0s
 => [agents-nginx 1/3] FROM docker.io/library/nginx:latest@sha256:91734281c0ebfc6f1aea979cffe  0.0s
 => => resolve docker.io/library/nginx:latest@sha256:91734281c0ebfc6f1aea979cffeed5079cfe7862  0.0s
 => [agents-nginx internal] load build context                                                 0.1s
 => => transferring context: 5.25MB                                                            0.1s
 => CACHED [agents-nginx 2/3] COPY ./nginx/nginx_local.conf /etc/nginx/nginx.conf              0.0s
 => CACHED [agents-nginx 3/3] COPY ./frontend/out /var/www/html                                0.0s
 => [agents-nginx] exporting to docker image format                                            0.6s
 => => exporting layers                                                                        0.0s
 => => exporting manifest sha256:1888f81dab1c5990b19108c1d3abaf4dd7090f88e80f0c9a388c563f011a  0.0s
 => => exporting config sha256:1f87bd5f28380f7c873e8e01df5a52dbf16b388ad291dd7db9109df45196db  0.0s
 => => sending tarball                                                                         0.6s
 => [agents-nginx] importing to docker                                                         0.0s
 => [agents-nginx] resolving provenance for metadata file                                      0.0s
```

After (uv pip install takes ~16s, end to end takes 48s):
```
[+] Building 48.0s (29/29) FINISHED                               docker-container:jolly_cartwright
 => [agents-python-server internal] load build definition from dockerfile.agents-python-serve  0.0s
 => => transferring dockerfile: 1.36kB                                                         0.0s
 => [agents-python-server internal] load metadata for docker.io/library/python:3.12-slim       0.9s
 => [agents-python-server internal] load .dockerignore                                         0.0s
 => => transferring context: 91B                                                               0.0s
 => [agents-python-server  1/11] FROM docker.io/library/python:3.12-slim@sha256:34656cd904563  0.0s
 => => resolve docker.io/library/python:3.12-slim@sha256:34656cd90456349040784165b9decccbcee4  0.0s
 => [agents-python-server internal] load build context                                         0.0s
 => => transferring context: 147B                                                              0.0s
 => CACHED [agents-python-server  2/11] WORKDIR /backend                                       0.0s
 => CACHED [agents-python-server  3/11] RUN apt-get update && apt-get install -y python3-pip   0.0s
 => CACHED [agents-python-server  4/11] RUN pip install uv                                     0.0s
 => CACHED [agents-python-server  5/11] COPY ./backend/requirements.txt /root/requirements.tx  0.0s
 => [agents-python-server  6/11] RUN uv pip install --system --upgrade setuptools &&     uv   16.9s
 => [agents-python-server  7/11] RUN touch /agent-logs-out                                     0.1s 
 => [agents-python-server  8/11] RUN apt-get update && apt-get install -y --no-install-recomm  1.8s
 => [agents-python-server  9/11] RUN curl https://packages.microsoft.com/keys/microsoft.asc |  0.8s
 => [agents-python-server 10/11] RUN apt-get update && apt-get install -y --no-install-recomm  2.7s
 => [agents-python-server 11/11] RUN apt-get clean && rm -rf /var/lib/apt/lists/*              0.0s
 => [agents-python-server] exporting to docker image format                                   22.1s
 => => exporting layers                                                                       12.5s
 => => exporting manifest sha256:dcc8bb9cefd5a92bbafde9b98fc706eced7283c7ba00a99f2752fc7fcb5c  0.0s
 => => exporting config sha256:abde51bb3df2c2c0c6d20b241eb763659ebe3db386434caad113bc1b2c0ee1  0.0s
 => => sending tarball                                                                         9.6s
 => [agents-python-server] importing to docker                                                 6.0s
 => => loading layer 6e507d707712 360.45kB / 35.06MB                                           6.0s
 => => loading layer 34fbaea6f0db 458B / 458B                                                  5.7s
 => => loading layer 1148f82bb321 188.84MB / 189.35MB                                          5.7s
 => => loading layer 903865ca7a9e 102B / 102B                                                  0.1s
 => => loading layer 8706b225d10b 32.77kB / 2.03MB                                             0.1s
 => => loading layer 631bfcb4648f 971B / 971B                                                  0.1s
 => => loading layer 1b0c80e2f137 32.77kB / 2.10MB                                             0.1s
 => => loading layer 5b5c1b90daaf 498B / 498B                                                  0.0s
 => [agents-python-server] resolving provenance for metadata file                              0.0s
 => [agents-nginx internal] load build definition from dockerfile.agents-nginx                 0.0s
 => => transferring dockerfile: 594B                                                           0.0s
 => [agents-nginx internal] load metadata for docker.io/library/nginx:latest                   2.0s
 => [agents-nginx auth] library/nginx:pull token for registry-1.docker.io                      0.0s
 => [agents-nginx internal] load .dockerignore                                                 0.0s
 => => transferring context: 91B                                                               0.0s
 => [agents-nginx 1/3] FROM docker.io/library/nginx:latest@sha256:91734281c0ebfc6f1aea979cffe  0.0s
 => => resolve docker.io/library/nginx:latest@sha256:91734281c0ebfc6f1aea979cffeed5079cfe7862  0.0s
 => [agents-nginx internal] load build context                                                 0.1s
 => => transferring context: 5.25MB                                                            0.1s
 => CACHED [agents-nginx 2/3] COPY ./nginx/nginx_local.conf /etc/nginx/nginx.conf              0.0s
 => CACHED [agents-nginx 3/3] COPY ./frontend/out /var/www/html                                0.0s
 => [agents-nginx] exporting to docker image format                                            0.6s
 => => exporting layers                                                                        0.0s
 => => exporting manifest sha256:1888f81dab1c5990b19108c1d3abaf4dd7090f88e80f0c9a388c563f011a  0.0s
 => => exporting config sha256:1f87bd5f28380f7c873e8e01df5a52dbf16b388ad291dd7db9109df45196db  0.0s
 => => sending tarball                                                                         0.6s
 => [agents-nginx] importing to docker                                                         0.0s
 => [agents-nginx] resolving provenance for metadata file                                      0.0s
```

If we re-run `docker compose up -d --build`, unlike the pip version, `uv` uses a completely cached version of the python deps (taking 0.0s), reducing the end-to-end build time to 6.5s!
```
[+] Building 6.5s (29/29) FINISHED                                docker-container:jolly_cartwright
 => [agents-python-server internal] load build definition from dockerfile.agents-python-serve  0.0s
 => => transferring dockerfile: 1.36kB                                                         0.0s
 => [agents-python-server internal] load metadata for docker.io/library/python:3.12-slim       1.8s
 => [agents-python-server auth] library/python:pull token for registry-1.docker.io             0.0s
 => [agents-python-server internal] load .dockerignore                                         0.0s
 => => transferring context: 91B                                                               0.0s
 => [agents-python-server  1/11] FROM docker.io/library/python:3.12-slim@sha256:34656cd904563  0.0s
 => => resolve docker.io/library/python:3.12-slim@sha256:34656cd90456349040784165b9decccbcee4  0.0s
 => [agents-python-server internal] load build context                                         0.0s
 => => transferring context: 721B                                                              0.0s
 => CACHED [agents-python-server  2/11] WORKDIR /backend                                       0.0s
 => CACHED [agents-python-server  3/11] RUN apt-get update && apt-get install -y python3-pip   0.0s
 => CACHED [agents-python-server  4/11] RUN pip install uv                                     0.0s
 => CACHED [agents-python-server  5/11] COPY ./backend/requirements.txt /root/requirements.tx  0.0s
 => CACHED [agents-python-server  6/11] RUN uv pip install --system --upgrade setuptools &&    0.0s
 => CACHED [agents-python-server  7/11] RUN touch /agent-logs-out                              0.0s
 => CACHED [agents-python-server  8/11] RUN apt-get update && apt-get install -y --no-install  0.0s
 => CACHED [agents-python-server  9/11] RUN curl https://packages.microsoft.com/keys/microsof  0.0s
 => CACHED [agents-python-server 10/11] RUN apt-get update && apt-get install -y --no-install  0.0s
 => CACHED [agents-python-server 11/11] RUN apt-get clean && rm -rf /var/lib/apt/lists/*       0.0s
 => [agents-python-server] exporting to docker image format                                    3.5s
 => => exporting layers                                                                        0.0s
 => => exporting manifest sha256:dcc8bb9cefd5a92bbafde9b98fc706eced7283c7ba00a99f2752fc7fcb5c  0.0s
 => => exporting config sha256:abde51bb3df2c2c0c6d20b241eb763659ebe3db386434caad113bc1b2c0ee1  0.0s
 => => sending tarball                                                                         3.5s
 => [agents-python-server] importing to docker                                                 0.0s
 => [agents-python-server] resolving provenance for metadata file                              0.0s
 => [agents-nginx internal] load build definition from dockerfile.agents-nginx                 0.0s
 => => transferring dockerfile: 594B                                                           0.0s
 => [agents-nginx internal] load metadata for docker.io/library/nginx:latest                   0.4s
 => [agents-nginx internal] load .dockerignore                                                 0.0s
 => => transferring context: 91B                                                               0.0s
 => [agents-nginx 1/3] FROM docker.io/library/nginx:latest@sha256:91734281c0ebfc6f1aea979cffe  0.0s
 => => resolve docker.io/library/nginx:latest@sha256:91734281c0ebfc6f1aea979cffeed5079cfe7862  0.0s
 => [agents-nginx internal] load build context                                                 0.0s
 => => transferring context: 5.25MB                                                            0.0s
 => CACHED [agents-nginx 2/3] COPY ./nginx/nginx_local.conf /etc/nginx/nginx.conf              0.0s
 => CACHED [agents-nginx 3/3] COPY ./frontend/out /var/www/html                                0.0s
 => [agents-nginx] exporting to docker image format                                            0.6s
 => => exporting layers                                                                        0.0s
 => => exporting manifest sha256:1888f81dab1c5990b19108c1d3abaf4dd7090f88e80f0c9a388c563f011a  0.0s
 => => exporting config sha256:1f87bd5f28380f7c873e8e01df5a52dbf16b388ad291dd7db9109df45196db  0.0s
 => => sending tarball                                                                         0.6s
 => [agents-nginx] importing to docker                                                         0.0s
 => [agents-nginx] resolving provenance for metadata file                                      0.0s
```