### PR TITLE
Add coffee data

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,7 +1,5 @@
 # replace the values here with your own
 SALT="default_salt"
-DEFOG_API_KEYS=123,456
-DEFOG_API_KEY_NAMES="Dataset 1,Dataset 2"
 GOOGLE_CLIENT_ID=""
 SLACK_BOT_TOKEN=""
 BUTTON_TEXT="Ask Defog"

--- a/backend/adhoc/README.md
+++ b/backend/adhoc/README.md
@@ -19,14 +19,7 @@ users = [
 
 ## Insert User DB Creds
 
-You can start by adding the following api_key's and key names to your `.env` file like below:
-
-```sh
-DEFOG_API_KEYS="456,123,test_restaurant,test_macmillan"
-DEFOG_API_KEY_NAMES="Housing,Cards,Restaurant,Macmillan" # feel free to edit to whatever you want displayed on the UI
-```
-
-This script inserts multiple test user and db creds data into the database, so that we can skip the db connection setup step on the UI. It needs to be run from within the docker container as such:
+Next, update the `insert_user_db_creds.py` file with the db name and db creds data in a dictionary in the `databases` list. Then, run the following command to insert the data into the database:
 
 ```sh
 $ docker exec -it defog-self-hosted-agents-python-server-1 /bin/bash -c "python adhoc/insert_user_db_creds.py"
@@ -34,9 +27,12 @@ $ docker exec -it defog-self-hosted-agents-python-server-1 /bin/bash -c "python 
 
 This script is idempotent, so it can be run multiple times without any issues. We will update the existing users and db creds if they already exist, instead of throwing an error or creating duplicates.
 
-We can also insert metadata for the imported tables. This script is idempotent, so it can be run multiple times without any issues. We will update the existing metadata if it already exists, instead of throwing an error or creating duplicates.
+## Insert Metadata
+
+We can also insert metadata for the imported tables. Update the `insert_metadata.py` file with your desired metadata as a dictionary whose keys are the table names and values are lists of dictionaries, each containing the metadata for a column. Then, run the following command to insert the data into the database:
 
 ```sh
 $ docker exec -it defog-self-hosted-agents-python-server-1 /bin/bash -c "python adhoc/insert_metadata.py"
 ```
 
+This script is idempotent, so it can be run multiple times without any issues. We will update the existing metadata if it already exists, instead of throwing an error or creating duplicates.

--- a/backend/adhoc/insert_metadata.py
+++ b/backend/adhoc/insert_metadata.py
@@ -1210,3 +1210,189 @@ try:
                 )
 except Exception as e:
     print(f"Error inserting metadata for ({cricket_api_key}) into metadata:\n{e}")
+
+
+# Insert metadata for coffee export
+coffee_export_api_key = "Coffee Export"
+coffee_export_metadata = {
+    "coffee_export": [
+        {
+            "data_type": "character varying",
+            "column_name": "country",
+            "column_description": "Name of the country exporting coffee"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "1990",
+            "column_description": "Coffee export data for the year 1990"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "1991",
+            "column_description": "Coffee export data for the year 1991"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "1992",
+            "column_description": "Coffee export data for the year 1992"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "1993",
+            "column_description": "Coffee export data for the year 1993"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "1994",
+            "column_description": "Coffee export data for the year 1994"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "1995",
+            "column_description": "Coffee export data for the year 1995"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "1996",
+            "column_description": "Coffee export data for the year 1996"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "1997",
+            "column_description": "Coffee export data for the year 1997"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "1998",
+            "column_description": "Coffee export data for the year 1998"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "1999",
+            "column_description": "Coffee export data for the year 1999"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "2000",
+            "column_description": "Coffee export data for the year 2000"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "2001",
+            "column_description": "Coffee export data for the year 2001"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "2002",
+            "column_description": "Coffee export data for the year 2002"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "2003",
+            "column_description": "Coffee export data for the year 2003"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "2004",
+            "column_description": "Coffee export data for the year 2004"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "2005",
+            "column_description": "Coffee export data for the year 2005"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "2006",
+            "column_description": "Coffee export data for the year 2006"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "2007",
+            "column_description": "Coffee export data for the year 2007"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "2008",
+            "column_description": "Coffee export data for the year 2008"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "2009",
+            "column_description": "Coffee export data for the year 2009"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "2010",
+            "column_description": "Coffee export data for the year 2010"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "2011",
+            "column_description": "Coffee export data for the year 2011"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "2012",
+            "column_description": "Coffee export data for the year 2012"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "2013",
+            "column_description": "Coffee export data for the year 2013"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "2014",
+            "column_description": "Coffee export data for the year 2014"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "2015",
+            "column_description": "Coffee export data for the year 2015"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "2016",
+            "column_description": "Coffee export data for the year 2016"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "2017",
+            "column_description": "Coffee export data for the year 2017"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "2018",
+            "column_description": "Coffee export data for the year 2018"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "2019",
+            "column_description": "Coffee export data for the year 2019"
+        },
+        {
+            "data_type": "integer",
+            "column_name": "total_export",
+            "column_description": "Total coffee exports over all years",
+        },
+    ],
+}
+
+try:
+    with engine.begin() as conn:
+        # delete all existing metadata for the coffee_export api key
+        conn.execute(delete(Metadata).where(Metadata.db_name == coffee_export_api_key))
+        for table in coffee_export_metadata:
+            for column in coffee_export_metadata[table]:
+                conn.execute(
+                    insert(Metadata).values(
+                        db_name=coffee_export_api_key,
+                        table_name=table,
+                        column_name=column["column_name"],
+                        data_type=column["data_type"],
+                        column_description=column["column_description"],
+                    )
+                )
+except Exception as e:
+    print(f"Error inserting metadata for ({coffee_export_api_key}) into metadata:\n{e}")

--- a/backend/adhoc/insert_user_db_creds.py
+++ b/backend/adhoc/insert_user_db_creds.py
@@ -44,6 +44,10 @@ users = [
     },
     {
         "username": "jp@defog.ai",
+    },
+    {
+        "username": "Coffee Export",
+        "password": "test",
     }
 ]
 databases = [
@@ -74,6 +78,10 @@ databases = [
     {
         "db_name": "Cricket",
         "database": "cricket",
+    },
+    {
+        "db_name": "Coffee Export",
+        "database": "coffee_export",
     },
 ]
 DB_CREDS = {

--- a/backend/generic_utils.py
+++ b/backend/generic_utils.py
@@ -1,22 +1,11 @@
 import copy
-import httpx
-import os
-import sqlparse
-from datetime import datetime
 import re
+from datetime import datetime
 
+import httpx
+import sqlparse
 from db_utils import get_db_names
-from utils_logging import LOGGER, LOG_LEVEL, truncate_obj
-
-DEFOG_API_KEYS = os.environ.get("DEFOG_API_KEYS")
-if not DEFOG_API_KEYS:
-    DEFOG_API_KEYS = os.environ.get(
-        "DEFOG_API_KEY"
-    )  # default to old env var for backwards compatibility
-
-    LOGGER.warning(
-        f"DEFOG_API_KEYS not set. Defaulting to DEFOG_API_KEY: {DEFOG_API_KEYS}"
-    )
+from utils_logging import LOG_LEVEL, LOGGER, truncate_obj
 
 
 async def make_request(url, data, timeout=180, log_time=False):

--- a/backend/request_models.py
+++ b/backend/request_models.py
@@ -217,3 +217,11 @@ class UploadFileAsDBRequest(UserRequest):
     """
     file_name: str
     tables: dict[str, UserTable]
+
+
+class AnswerQuestionFromDatabaseRequest(UserRequest):
+    """
+    Request model for answering a question from a database.
+    """
+    question: str
+    model: str | None = None

--- a/backend/tools/analysis_models.py
+++ b/backend/tools/analysis_models.py
@@ -1,14 +1,22 @@
 from pydantic import BaseModel, Field
 from typing import List, Any
 
+
 class AnswerQuestionFromDatabaseInput(BaseModel):
     question: str = Field(..., description="The question to generate SQL for")
-    db_name: str = Field(..., description="The name of database to generate SQL for. "
-    "This will help the function identify the DDL statements and instruction manual "
-    "associated with this database.")
+    db_name: str = Field(
+        ...,
+        description="The name of database to generate SQL for. "
+        "This will help the function identify the DDL statements and instruction manual "
+        "associated with this database.",
+    )
+
 
 class AnswerQuestionFromDatabaseOutput(BaseModel):
     sql: str = Field(..., description="The SQL query generated from the question")
-    colnames: List[str] = Field(..., description="The column names of the table (header row)")
-    rows: List[List[Any]] = Field(..., description="The rows of the table generated from SQL (data rows)")
-
+    colnames: List[str] = Field(
+        ..., description="The column names of the table (header row)"
+    )
+    rows: List[List[Any]] = Field(
+        ..., description="The rows of the table generated from SQL (data rows)"
+    )

--- a/backend/tools/analysis_tools.py
+++ b/backend/tools/analysis_tools.py
@@ -1,16 +1,24 @@
-from tools.analysis_models import AnswerQuestionFromDatabaseInput, AnswerQuestionFromDatabaseOutput
+from tools.analysis_models import (
+    AnswerQuestionFromDatabaseInput,
+    AnswerQuestionFromDatabaseOutput,
+)
+from utils_logging import LOG_LEVEL, LOGGER
 from utils_sql import generate_sql_query
+from db_utils import get_db_type_creds
 from defog.query import async_execute_query_once
 
-async def answer_question_from_database(input: AnswerQuestionFromDatabaseInput) -> AnswerQuestionFromDatabaseOutput:
+
+async def answer_question_from_database(
+    input: AnswerQuestionFromDatabaseInput,
+) -> AnswerQuestionFromDatabaseOutput:
     """
     Given a *single* question for a *single* database, this function will first generate a SQL query to answer the question.
     Then, it will execute the SQL query on the database and return the results.
     """
     question = input.question
     db_name = input.db_name
-    
-    print(question, flush=True)
+
+    LOGGER.debug(f"Question to answer from database ({db_name}):\n{question}\n")
 
     sql_response = await generate_sql_query(
         question=question,
@@ -19,10 +27,15 @@ async def answer_question_from_database(input: AnswerQuestionFromDatabaseInput) 
     sql = sql_response["sql"]
 
     # execute SQL
-    colnames, rows = await async_execute_query_once(db_type=db_type, db_creds=db_creds, query=sql)
+    db_type, db_creds = await get_db_type_creds(db_name)
+    colnames, rows = await async_execute_query_once(
+        db_type=db_type, db_creds=db_creds, query=sql
+    )
 
-    print(colnames, flush=True)
-    print(rows[:100], flush=True)
+    if LOG_LEVEL == "DEBUG":
+        LOGGER.debug(f"Column names:\n{colnames}\n")
+        first_20_rows_str = "\n".join([str(row) for row in rows[:20]])
+        LOGGER.debug(f"First 20 rows:\n{first_20_rows_str}\n")
 
     # known issue: if the query returns way too much data, it may run out of context window limits
 

--- a/backend/tools/tool_routes.py
+++ b/backend/tools/tool_routes.py
@@ -1,29 +1,33 @@
-from fastapi import APIRouter, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Request
+from llm_api import ALL_MODELS, O3_MINI
+from request_models import AnswerQuestionFromDatabaseRequest
 from tools.analysis_tools import answer_question_from_database
 from defog.llm.utils import chat_async
+from auth_utils import validate_user_request
 
-router = APIRouter()
+router = APIRouter(
+    dependencies=[Depends(validate_user_request)],
+)
+
 
 @router.post("/answer_question_from_database")
-async def answer_question_from_database_route(request: Request):
+async def answer_question_from_database_route(
+    request: AnswerQuestionFromDatabaseRequest,
+):
     """
     Route used for testing purposes.
     Generates SQL from a question and database.
     """
-    params = await request.json()
-    question = params.get("question")
-    db_name = params.get("db_name")
-    model = params.get("model", "o3-mini")
+    question = request.question
+    db_name = request.db_name
+    model = request.model if request.model and request.model in ALL_MODELS else O3_MINI
     try:
         tools = [answer_question_from_database]
         return await chat_async(
             model=model,
             tools=tools,
             messages=[
-                {
-                    "role": "developer",
-                    "content": "Formatting re-enabled"
-                },
+                {"role": "developer", "content": "Formatting re-enabled"},
                 {
                     "role": "user",
                     "content": f"""{question} Look in the database {db_name} for your answers, and feel free to continue asking multiple questions from the database if you need to. I would rather that you ask a lot of questions than too few.
@@ -33,8 +37,9 @@ Try to aggregate data in clear and understandable buckets.
 Please give your final answer as a descriptive report.
 
 For each point that you make in the report, please include the relevant SQL query that was used to generate the data for it. You can include as many SQL queries as you want, including multiple SQL queries for one point.
-"""
-}],
+""",
+                },
+            ],
         )
     except Exception as e:
         raise HTTPException(status_code=400, detail=str(e))

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,8 +22,6 @@ services:
     environment:
       - SALT=${SALT:-default_salt}
       - DEFOG_API_KEY=${DEFOG_API_KEY} # for backwards compatibility. avoid using DEFOG_API_KEY going forward due to potential conflicts with usage in defog-python
-      - DEFOG_API_KEYS=${DEFOG_API_KEYS}
-      - DEFOG_API_KEY_NAMES=${DEFOG_API_KEY_NAMES}
       - DEFOG_BASE_URL=${DEFOG_BASE_URL:-https://api.defog.ai}
       - GOOGLE_CLIENT_ID=${GOOGLE_CLIENT_ID}
       - SLACK_BOT_TOKEN=${SLACK_BOT_TOKEN}


### PR DESCRIPTION
# Changes

Just some simple cleanups + code facilitating setup / testing.

* Add coffee data
* Remove `DEFOG_API_KEYS` and `DEFOG_API_KEY_NAMES` as these are unused
* Updated instructions for adding adhoc data

# Testing

Tested with the coffee export db:
```
curl --location '0.0.0.0:1235/answer_question_from_database' \
--header 'Content-Type: application/json' \
--data '{
    "token": "6244004c7501f4fbfef3e9a4366a97be1aacfb1e139824fcbb3aa0f604583a57",
    "db_name": "Coffee Export",
    "question": "What are the interesting trends in coffee production from 1990 to 2019? Focus on country level insights, and changes in composition"
}'
```
Response's content (markdown) in next comment for easier perusal. Output was as expected / described as in [DEF-738](https://linear.app/defog/issue/DEF-738/implement-thesis-competition-for-oracle-answers)