### PR TITLE
Synthesize Report

### DIFF
--- a/backend/request_models.py
+++ b/backend/request_models.py
@@ -225,3 +225,14 @@ class AnswerQuestionFromDatabaseRequest(UserRequest):
     """
     question: str
     model: str | None = None
+
+
+class SynthesizeReportFromQuestionRequest(UserRequest):
+    """
+    Request model for synthesizing a report from a question.
+    `num_reports` is the number of intermediate reports to generate and
+    synthesize into a final report.
+    """
+    question: str
+    model: str | None = None
+    num_reports: int = 3

--- a/backend/tools/analysis_models.py
+++ b/backend/tools/analysis_models.py
@@ -20,3 +20,35 @@ class AnswerQuestionFromDatabaseOutput(BaseModel):
     rows: List[List[Any]] = Field(
         ..., description="The rows of the table generated from SQL (data rows)"
     )
+
+
+class GenerateReportFromQuestionInput(BaseModel):
+    question: str = Field(..., description="The initial question to generate SQL for")
+    model: str = Field(
+        ..., description="The name of the model to use for generating SQL. "
+    )
+    db_name: str = Field(..., description="The name of database to generate SQL for. ")
+    num_reports: int = Field(
+        default=1,
+        description="The number of reports to generate. "
+        "This input class is used for generating single and multiple reports."
+        "The default is 1.",
+    )
+
+
+class GenerateReportFromQuestionOutput(BaseModel):
+    report: str = Field(
+        ..., description="The final report generated from the questions"
+    )
+    sql_answers: List[AnswerQuestionFromDatabaseOutput] = Field(
+        ..., description="The SQL queries and data answers used to generate the report"
+    )
+
+
+class SynthesizeReportFromQuestionsOutput(BaseModel):
+    report: str = Field(
+        ..., description="The final report synthesized from the questions"
+    )
+    report_answers: List[GenerateReportFromQuestionOutput] = Field(
+        ..., description="The intermediate reports used to synthesize the final report"
+    )


### PR DESCRIPTION
# Approach

We first refactor report generation from the current test route into a proper function `generate_report_from_question` with clearly-defined input/output classes. We call this function asynchronously n-times in `synthesize_report_from_questions`, and then make a final call to combine and synthesize the outputs of the report insights. By composing these functions on top of each other, we facilitate 2 key usage patterns that we'd like to highlight:
- **Stacking**: leverage more and more refined outputs via "stacked tool calling"
- **Pooling**: reduce variance by making similar concurrent requests and pooling them (aka synthesis in this PR)

These ideas of stacking/pooling are largely reminiscent of [convnets](https://cs231n.github.io/convolutional-networks/) that rely on stacking convolution operators, while interleaving pooling operators in between to progressively shrink the input data's resolution.

## Stacked Tool Calling

For example, we could have another function calling `synthesize_report_from_questions` asynchronously n-times, to synthesize from a few synthesized reports. And then you can wrap that in another tool call to synthesize the synthesized synthesized reports. And then you can wrap that in yet another tool call to ... Practically, this allows us to use "high-level" insights for "higher-level" insights, which can power "higher-higher-level" insights. Another usage pattern is to use this sort of "stacking" for incremental/deeper explorations, where each additional depth of tool-calling explores a deeper layer of questions.

## Pooling

And if at any point in time we get a high variance of responses, we can parallelize the exact same calls and then synthesize/combine, which is what we did for `generate_report_from_question` since report generation has quite high variance between identical requests currently. By running the report generation multiple times, and presenting all of the results simultaneously to the LLM, the LLM can see which insights get "repeated"/"rehashed" the most and focus on those, while deprioritizing more "once-off" niche explorations.

# Testing

Here's a test request you can try running a few times:
```
curl --location '0.0.0.0:1235/synthesize_report_from_question' \
--header 'Content-Type: application/json' \
--data '{
    "token": "6244004c7501f4fbfef3e9a4366a97be1aacfb1e139824fcbb3aa0f604583a57",
    "db_name": "Coffee Export",
    "question": "What are the interesting trends in coffee production from 1990 to 2019? Focus on country level insights, and changes in composition",
    "num_reports": 5
}'
```

I'll put a sample of the response's final report I got in the following comment for easier perusal of the final markdown.