### PR TITLE
Fix prop name in OracleEmbed component

### DIFF
--- a/frontend/pages/reports.tsx
+++ b/frontend/pages/reports.tsx
@@ -60,7 +60,7 @@ export default function OracleDashboard() {
         <OracleEmbed
           apiEndpoint={process.env.NEXT_PUBLIC_AGENTS_ENDPOINT || ""}
           token={token}
-          initialKeyNames={dbNames}
+          initialDbNames={dbNames}
         />
       </Scaffolding>
     </div>


### PR DESCRIPTION
Fix prop name in OracleEmbed component based on [latest prop name](https://github.com/defog-ai/agents-ui-components/blob/8f8b2945ed0fc873a9de38a9ee9d3256b5121054/lib/components/oracle/embed/OracleEmbed.tsx#L63)

`pnpm run export` now works without issues.