### PR TITLE
DEF-779 Fix Excel file selection in file upload dialog

### DIFF
--- a/frontend/components/extract-metadata/DbUpload.tsx
+++ b/frontend/components/extract-metadata/DbUpload.tsx
@@ -34,7 +34,7 @@ export function DbUpload({
         <DropFiles
           showIcon={true}
           rootClassNames={twMerge("h-full", loading ? "hidden" : "")}
-          label="Drag and drop your file here, or"
+          label="Drag and drop your file here"
           acceptedFileTypes={[".csv", ".xlsx", ".xls"]}
           onFileSelect={async (ev) => {
             ev.preventDefault();

--- a/frontend/components/extract-metadata/DbUpload.tsx
+++ b/frontend/components/extract-metadata/DbUpload.tsx
@@ -35,6 +35,7 @@ export function DbUpload({
           showIcon={true}
           rootClassNames={twMerge("h-full", loading ? "hidden" : "")}
           label="Drag and drop your file here, or"
+          acceptedFileTypes={[".csv", ".xlsx", ".xls"]}
           onFileSelect={async (ev) => {
             ev.preventDefault();
             ev.stopPropagation();


### PR DESCRIPTION
## Summary
- Fixed issue where users couldn't select Excel files in the file picker dialog, while drag and drop was working correctly
- Added proper acceptedFileTypes prop to the DropFiles component to allow .xlsx and .xls file selection

## Test plan
- Verify users can now select Excel files using the file picker dialog
- Verify drag and drop functionality continues to work as expected for both Excel and CSV files

🤖 Generated with [Claude Code](https://claude.ai/code)