### PR TITLE
Use uvloop worker class instead of default asyncio

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -16,11 +16,11 @@ redis
 requests
 resend
 slack_sdk
-sqlalchemy
 sqlalchemy[asyncio]
 sqlalchemy-utils
 sqlglot
 sqlparse
+uvloop
 
 # sync db connectors
 databricks-sql-connector

--- a/backend/startup.sh
+++ b/backend/startup.sh
@@ -9,10 +9,10 @@ echo "PROD: $PROD"
 # Start the FastAPI server
 if [ "$PROD" = "no" ]; then
   echo "Running in development mode"
-  python3 -m hypercorn main:app -b 0.0.0.0:1235 --reload --log-level warning &
+  hypercorn main:app --workers 4 -b 0.0.0.0:1235 --log-level warning --worker-class uvloop --reload &
 else
   echo "Running in production mode"
-  python3 -m hypercorn main:app -b 0.0.0.0:1235 --log-level warning &
+  hypercorn main:app --workers 4 -b 0.0.0.0:1235 --log-level warning --worker-class uvloop &
 fi
 
 FASTAPI_PID=$!


### PR DESCRIPTION
Using `uvloop` as the worker class instead of the default `asyncio` worker class increases performance significantly - particularly for file uploads.

For reference, specifying uvloop reduced the file upload time for a 12MB CSV from 70seconds to just 1 second!

Also specified multiple workers (4) for better performance. This did not cause the speedups described above, but is very useful for ensuring that heavy CPU blocking tasks (like, say, pandas transformations) don't block the service for anyone.