### PR TITLE
Add session cost for code interpreter

### DIFF
--- a/backend/utils_file_uploads/excel_utils.py
+++ b/backend/utils_file_uploads/excel_utils.py
@@ -340,5 +340,6 @@ class ExcelUtils:
             * LLM_COSTS_PER_TOKEN[model]["cached_input_cost_per1k"]
         )
         cost *= 100
+        cost += 3 # cost of code interpreter session
         LOGGER.info(f"Run cost in cents: {cost}")
         return df


### PR DESCRIPTION
Added [additional cost](https://platform.openai.com/docs/assistants/tools/code-interpreter#:~:text=How%20it%20works,to%20one%20hour.) of running a code interpreter session. 