### PR TITLE
`is_table_dirty` check fixes/improvements

### DIFF
--- a/backend/file_upload_routes.py
+++ b/backend/file_upload_routes.py
@@ -44,12 +44,13 @@ async def upload_files_as_db(files, db_name: str | None = None) -> DbDetails:
     """
     if db_name is None:
         cleaned_db_name = clean_table_name(files[0].filename)
-        db_exists = await get_db_type_creds(cleaned_db_name)
-        if db_exists:
-            # add a random 3 digit integer to the end of the file name
-            cleaned_db_name = f"{cleaned_db_name}_{random.randint(1, 9999)}"
     else:
         cleaned_db_name = db_name
+
+    db_exists = await get_db_type_creds(cleaned_db_name)
+    if db_exists:
+        # add a random 3 digit integer to the end of the file name
+        cleaned_db_name = f"{cleaned_db_name}_{random.randint(1, 9999)}"
 
     tables = {}
 


### PR DESCRIPTION
Fixes/improves a few things:
1. We create a threshold of minimum 20 row dataframes for doing header checks (would fail on edge case: small csvs where _data rows_ might have repeating values, `df.head(3)` would also encompass the data rows)
2. Same as above threshold for repeated section header
3. For "Aggregate" check, we check the first and last 3 columns (in dfs with < 6 columns we check all), and instead of checking substring, we compare the full cell value of rows
4. Repeating pattern in columns is checked better now and logs the common prefix that was found.