### PR TITLE
fix excel parsing

### DIFF
--- a/backend/tests/test_backend_routes.py
+++ b/backend/tests/test_backend_routes.py
@@ -1555,7 +1555,7 @@ def test_upload_single_excel_sheet(admin_token):
     test_db_name = f"excel_single_{random.randint(1000, 9999)}"
     
     try:
-        # Skip if pandas or openpyxl are not installed
+        # Skip if pandas is not installed
         try:
             import pandas as pd
         except ImportError:
@@ -1740,7 +1740,7 @@ def test_upload_excel_file_with_multiple_sheets(admin_token):
     test_db_name = f"excel_sheets_{random.randint(1000, 9999)}"
     
     try:
-        # Skip if pandas or openpyxl are not installed
+        # Skip if pandas is not installed
         try:
             import pandas as pd
         except ImportError:

--- a/backend/utils_file_uploads/db_utils.py
+++ b/backend/utils_file_uploads/db_utils.py
@@ -125,11 +125,11 @@ class DbUtils:
         # Store original column names for type inference
         original_cols = list(df.columns)
 
-        # First ensure we have unique column names using our dedicated function
+        # Deduplicate column names
         unique_cols = DbUtils.deduplicate_column_names(df.columns)
         df.columns = unique_cols
         
-        # Then sanitize column names for SQL use
+        # Sanitize column names for SQL use
         safe_col_list = []
         seen_names = set()
 

--- a/backend/utils_file_uploads/excel_utils.py
+++ b/backend/utils_file_uploads/excel_utils.py
@@ -11,7 +11,6 @@ from io import BytesIO
 import traceback
 
 import pandas as pd
-import openpyxl
 from openai import AsyncOpenAI
 from defog.llm.utils import LLM_COSTS_PER_TOKEN
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@codemirror/lang-sql": "^6.7.0",
-    "@defogdotai/agents-ui-components": "1.7.0",
+    "@defogdotai/agents-ui-components": "1.7.1",
     "@react-oauth/google": "^0.12.1",
     "@types/react-dom": "19.0.0",
     "lodash.debounce": "^4.0.8",


### PR DESCRIPTION
This was caught as a result of @Muhammad18557 's tests!

Here's a description of what was happening:

We're parsing openpyxl sheets into a pandas this way:
```
# Convert worksheet data into Pandas DataFrame
df = pd.DataFrame(sheet.values)
```

But that `sheet.values` also includes the columns. So the resulting data that is put into the pg table is:

```
INFO:      0                     1          2              3       4
2025-03-13 11:19:07 0   ID                  Name  Food Type      City Name  Rating
2025-03-13 11:19:07 1    1       The Pasta House    Italian    Los Angeles     4.5
2025-03-13 11:19:07 2    2      The Burger Joint   American    Los Angeles     3.8
2025-03-13 11:19:07 3    3         The Sushi Bar   Japanese    Los Angeles     4.2
2025-03-13 11:19:07 4    4       The Pizza Place    Italian       New York     4.7
2025-03-13 11:19:07 5    5        The Steakhouse   American       New York     3.9
2025-03-13 11:19:07 6    6        The Ramen Shop   Japanese       New York     4.3
2025-03-13 11:19:07 7    7  The Tacos & Burritos    Mexican  San Francisco     4.1
2025-03-13 11:19:07 8    8        The Vegan Cafe      Vegan  San Francisco     4.6
2025-03-13 11:19:07 9    9         The BBQ Joint   American  San Francisco     3.7
2025-03-13 11:19:07 10  10     The Seafood Shack    Seafood          Miami     4.4
2025-03-13 11:19:07 11  11     The Seafood Shack    Seafood          Miami     4.6
```


Leading to the column names being `null` and metadata:

<img width="1268" alt="image" src="https://github.com/user-attachments/assets/1a48228e-40d5-476d-84b1-ae0e595c584e" />

---

Now we use the first row as header when doing `pd.Dataframe`


Pls update frontend before testing as well:
```
cd frontend
rm -rf node_modules
rm, -rf .next
pnpm i
pnpm dev
```


Running tests now passes:
`docker exec introspect-backend pytest tests/test_backend_routes.py -sv -k "test_upload_single_excel_sheet or test_upload_excel_file_with_multiple_sheets"`

Result:
```
/usr/local/lib/python3.12/site-packages/pytest_asyncio/plugin.py:207: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
============================= test session starts ==============================
platform linux -- Python 3.12.9, pytest-8.3.5, pluggy-1.5.0 -- /usr/local/bin/python
cachedir: .pytest_cache
rootdir: /backend
plugins: asyncio-0.25.3, anyio-4.8.0
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None
collecting ... collected 26 items / 24 deselected / 2 selected

tests/test_backend_routes.py::test_upload_single_excel_sheet 
Available columns in Excel table:
- price
- product
- quantity

--- Running cleanup for database: excel_single_5157 ---
--- Cleanup completed for database: excel_single_5157 ---
PASSED
tests/test_backend_routes.py::test_upload_excel_file_with_multiple_sheets 
--- Running cleanup for database: excel_sheets_5745 ---
--- Cleanup completed for database: excel_sheets_5745 ---
PASSED
--- Running cleanup for test_db ---
--- Test cleanup completed successfully ---


======================= 2 passed, 24 deselected in 1.32s =======================
```