### PR TITLE
Handle pdf(s) upload without db or excels/csvs

### DIFF
--- a/backend/file_upload_routes.py
+++ b/backend/file_upload_routes.py
@@ -4,7 +4,7 @@ import time
 import traceback
 
 from pandas.errors import ParserError
-from fastapi import APIRouter, File, Request, UploadFile
+from fastapi import APIRouter, File, Request, UploadFile, HTTPException
 from fastapi.responses import JSONResponse, Response
 from request_models import (
     DbDetails,
@@ -191,6 +191,11 @@ async def upload_files(
         else:
             await upload_files_as_db(files=data_files, db_name=db_name)
     if len(pdf_files) > 0:
+        if db_name is None and len(data_files) == 0:
+            raise HTTPException(
+                status_code=400,
+                detail="To upload PDF files, you must either provide a database name or include at least one CSV/Excel file to create a new database"
+            )
         pdf_file_ids = await upload_pdf_files(pdf_files)
         await update_project_files(db_name, pdf_file_ids)
 


### PR DESCRIPTION
This PR fixes an [issue](https://linear.app/defog/issue/DEF-790/handle-pdf-upload-without-excelcsv-or-existing-db) related to pdf files uploading. Right now when a user tries to upload pdf (s) alone (without excel or csv) and has not already connected a database, it causes this in our backend server:
```
2025-03-14 07:14:35   File "/backend/file_upload_routes.py", line 197, in upload_files

2025-03-14 07:14:35     db_info = await get_db_info(db_name)

2025-03-14 07:14:35               ^^^^^^^^^^^^^^^^^^^^^^^^^^

2025-03-14 07:14:35   File "/backend/db_utils.py", line 84, in get_db_info

2025-03-14 07:14:35     raise Exception("No db creds found")

2025-03-14 07:14:35 Exception: No db creds found
```

We handle this by raising an exception for such case! Also made minor adjustments to the frontend to parse the detail in the error correctly!

Tests to make sure this does not break:
```
============================= test session starts ==============================
platform linux -- Python 3.12.9, pytest-8.3.5, pluggy-1.5.0
rootdir: /backend
plugins: asyncio-0.25.3, anyio-4.8.0
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=None
collected 26 items

tests/test_backend_routes.py ..........................                  [100%]

======================== 26 passed in 105.68s (0:01:45) ========================
muhammadabdullah@Muhammads-MacBook-Air-3 introspect % 
```

![Screenshot 2025-03-14 at 7 51 46 AM](https://github.com/user-attachments/assets/b4217c08-fb05-447b-9b7f-3567cbbb9992)


