### PR TITLE
DEF-796 Upload files to db

### DIFF
--- a/backend/auth_routes.py
+++ b/backend/auth_routes.py
@@ -53,8 +53,6 @@ async def login(req: LoginRequest):
         )
         user = result.scalar_one_or_none()
         
-        LOGGER.info(f"User found: {user}")
-
         if user:
             token = user.token
             user_type = user.user_type.value if hasattr(user, 'user_type') and user.user_type else "ADMIN"

--- a/backend/file_upload_routes.py
+++ b/backend/file_upload_routes.py
@@ -137,8 +137,9 @@ async def upload_files_to_db(files, db_name: str | None = None) -> DbDetails:
         connection_uri = f"mssql+aioodbc://{db_creds_to_use['user']}:{db_creds_to_use['password']}@{db_creds_to_use['host']}:{db_creds_to_use['port']}/{db_creds_to_use['database']}"
     
     elif db_type == "redshift":
-        # Redshift uses PostgreSQL-compatible connection string
-        connection_uri = f"postgresql+asyncpg://{db_creds_to_use['user']}:{db_creds_to_use['password']}@{db_creds_to_use['host']}:{db_creds_to_use['port']}/{db_creds_to_use['database']}"
+        # Redshift should use psycopg2 instead of asyncpg for better compatibility
+        # Add specific connection parameters for Redshift
+        connection_uri = f"postgresql+psycopg2://{db_creds_to_use['user']}:{db_creds_to_use['password']}@{db_creds_to_use['host']}:{db_creds_to_use['port']}/{db_creds_to_use['database']}?sslmode=prefer&application_name=defog&client_encoding=utf8"
     
     elif db_type in ["snowflake", "bigquery", "databricks"]:
         # For cloud databases, use specific connection methods from the creds

--- a/backend/utils_file_uploads/__init__.py
+++ b/backend/utils_file_uploads/__init__.py
@@ -26,6 +26,7 @@ from .legacy import (
     guess_column_type,
     convert_values_to_postgres_type,
     create_table_sql,
+    export_df_to_db,
     export_df_to_postgres,
 )
 
@@ -54,6 +55,7 @@ __all__ = [
     "guess_column_type",
     "convert_values_to_postgres_type",
     "create_table_sql",
+    "export_df_to_db",
     "export_df_to_postgres",
 
     # sqlalchemy

--- a/backend/utils_file_uploads/db_utils.py
+++ b/backend/utils_file_uploads/db_utils.py
@@ -4,6 +4,9 @@ Utilities for database operations.
 
 import numpy as np
 import pandas as pd
+import os
+import json
+import tempfile
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import create_async_engine
 
@@ -81,13 +84,14 @@ class DbUtils:
         return safe_cols
 
     @staticmethod
-    def create_table_sql(table_name: str, columns: dict[str, str]):
+    def create_table_sql(table_name: str, columns: dict[str, str], db_type: str = "postgres"):
         """
-        Build a CREATE TABLE statement.
+        Build a CREATE TABLE statement based on database type.
 
         Args:
             table_name: Name of the table to create
             columns: Dictionary mapping column names to data types
+            db_type: Type of database (postgres, mysql, sqlserver, redshift, snowflake, bigquery, etc.)
 
         Returns:
             SQL statement for creating the table
@@ -95,26 +99,83 @@ class DbUtils:
         cols = []
         for col_name, col_type in columns.items():
             safe_col_name = NameUtils.sanitize_column_name(col_name)
-            cols.append(f'"{safe_col_name}" {col_type}')
+            
+            # Convert PostgreSQL types to target database types if needed
+            target_type = col_type
+            
+            # Database-specific type mappings
+            if db_type == "bigquery":
+                # Map PostgreSQL types to BigQuery types
+                if col_type == "TEXT":
+                    target_type = "STRING"
+                elif col_type in ["BIGINT", "INTEGER"]:
+                    target_type = "INT64"
+                elif col_type == "DOUBLE PRECISION":
+                    target_type = "FLOAT64"
+                elif "TIMESTAMP" in col_type:
+                    target_type = "TIMESTAMP"
+                elif "TIME" in col_type:
+                    target_type = "TIME"
+            elif db_type == "snowflake":
+                # Map PostgreSQL types to Snowflake types
+                if col_type == "DOUBLE PRECISION":
+                    target_type = "FLOAT"
+                # Snowflake compatible with most PostgreSQL types
+            elif db_type == "redshift":
+                # Redshift uses similar types to PostgreSQL
+                pass
+            
+            # Handle different database identifier quoting styles
+            if db_type == "mysql":
+                # MySQL uses backticks
+                cols.append(f'`{safe_col_name}` {target_type}')
+            elif db_type == "sqlserver":
+                # SQL Server uses square brackets
+                cols.append(f'[{safe_col_name}] {target_type}')
+            elif db_type == "bigquery":
+                # BigQuery doesn't require quotes for standard identifiers
+                cols.append(f'{safe_col_name} {target_type}')
+            elif db_type == "snowflake":
+                # Snowflake uses double quotes but uppercase identifiers by default
+                cols.append(f'"{safe_col_name}" {target_type}')
+            else:
+                # Default to PostgreSQL style with double quotes (works for Redshift too)
+                cols.append(f'"{safe_col_name}" {target_type}')
 
         cols_str = ", ".join(cols)
-        return f'CREATE TABLE "{table_name}" ({cols_str});'
+        
+        # Generate CREATE TABLE statement with appropriate identifier quoting and syntax
+        if db_type == "mysql":
+            return f'CREATE TABLE `{table_name}` ({cols_str});'
+        elif db_type == "sqlserver":
+            return f'CREATE TABLE [{table_name}] ({cols_str});'
+        elif db_type == "bigquery":
+            return f'CREATE TABLE {table_name} ({cols_str});'
+        elif db_type == "snowflake":
+            return f'CREATE OR REPLACE TABLE "{table_name}" ({cols_str});'
+        else:
+            # Default PostgreSQL/Redshift style
+            return f'CREATE TABLE "{table_name}" ({cols_str});'
 
     @staticmethod
-    async def export_df_to_postgres(
+    async def export_df_to_db(
         df: pd.DataFrame,
         table_name: str,
         db_connection_string: str,
+        db_type: str = "postgres",
         chunksize: int = 5000,
+        db_creds: dict = None,
     ):
         """
-        Export a pandas DataFrame to PostgreSQL.
+        Export a pandas DataFrame to a database.
 
         Args:
             df: DataFrame to export
             table_name: Name of the target table
             db_connection_string: Database connection string
+            db_type: Type of database (postgres, mysql, sqlserver, redshift, snowflake, bigquery, etc.)
             chunksize: Number of rows to insert at once
+            db_creds: Additional credentials needed for some DB types (like BigQuery)
 
         Returns:
             Dictionary with success status and inferred types
@@ -125,8 +186,19 @@ class DbUtils:
         # Store original column names for type inference
         original_cols = list(df.columns)
 
-        # Deduplicate column names
-        unique_cols = DbUtils.deduplicate_column_names(df.columns)
+        # Get appropriate column name max length for the database type
+        max_col_length = 59  # Default for PostgreSQL
+        if db_type == "mysql":
+            max_col_length = 64
+        elif db_type == "sqlserver":
+            max_col_length = 128
+        elif db_type == "bigquery":
+            max_col_length = -1  # BigQuery has no practical limit
+        elif db_type == "snowflake":
+            max_col_length = 255
+        
+        # Deduplicate column names with appropriate length limit
+        unique_cols = DbUtils.deduplicate_column_names(df.columns, max_col_length)
         df.columns = unique_cols
         
         # Sanitize column names for SQL use
@@ -152,6 +224,25 @@ class DbUtils:
         # Update dataframe with sanitized column names
         df.columns = safe_col_list
 
+        # Special handling for BigQuery, which uses different approach
+        if db_type == "bigquery" and db_creds:
+            try:
+                return await DbUtils._export_df_to_bigquery(
+                    df, table_name, db_creds, col_name_mapping
+                )
+            except Exception as e:
+                raise Exception(f"Failed to export to BigQuery: {str(e)}")
+        
+        # Special handling for Snowflake, which may have additional parameters
+        if db_type == "snowflake" and db_creds:
+            try:
+                return await DbUtils._export_df_to_snowflake(
+                    df, table_name, db_connection_string, db_creds, col_name_mapping
+                )
+            except Exception as e:
+                raise Exception(f"Failed to export to Snowflake: {str(e)}")
+
+        # For SQL databases (PostgreSQL, MySQL, SQL Server, Redshift)
         # Create a SQLAlchemy engine
         engine = create_async_engine(db_connection_string)
 
@@ -170,7 +261,274 @@ class DbUtils:
 
         LOGGER.info(inferred_types)
 
-        # Convert values to appropriate PostgreSQL types
+        # Convert values based on database type
+        converted_df = df.copy()
+        for col in df.columns:
+            try:
+                # PostgreSQL conversion is the base for most SQL databases
+                # We could implement specific conversions for each DB type if needed
+                converted_df[col] = df[col].map(
+                    lambda value: TypeUtils.convert_values_to_postgres_type(
+                        value, target_type=inferred_types[col]
+                    )
+                )
+            except Exception as e:
+                raise Exception(
+                    f"Failed to convert values for column {col} in table {table_name}: {e}"
+                )
+
+        # Create table SQL
+        try:
+            create_stmt = DbUtils.create_table_sql(table_name, inferred_types, db_type)
+        except Exception as e:
+            raise Exception(
+                f"Failed to create CREATE TABLE statement for {table_name}: {e}"
+            )
+            
+        # Database-specific SQL handling for DROP and CREATE
+        if db_type == "mysql":
+            # MySQL uses backticks for identifiers
+            drop_sql = f"DROP TABLE IF EXISTS `{table_name}`;"
+        elif db_type == "sqlserver":
+            # SQL Server uses square brackets and different DROP syntax
+            drop_sql = f"IF OBJECT_ID('{table_name}', 'U') IS NOT NULL DROP TABLE [{table_name}];"
+        elif db_type == "redshift":
+            # Redshift similar to PostgreSQL
+            drop_sql = f'DROP TABLE IF EXISTS "{table_name}";'
+        else:
+            # Default PostgreSQL style 
+            drop_sql = f'DROP TABLE IF EXISTS "{table_name}";'
+
+        # Execute DROP and CREATE statements
+        try:
+            async with engine.begin() as conn:
+                await conn.execute(text(drop_sql))
+                await conn.execute(text(create_stmt))
+        except Exception as e:
+            raise Exception(f"Failed to create table: {str(e)}")
+
+        # Prepare INSERT statement based on DB type
+        if db_type == "mysql":
+            # MySQL uses backticks
+            insert_cols = ", ".join(f"`{c}`" for c in safe_col_list)
+            placeholders = ", ".join([f":{c}" for c in safe_col_list])
+            insert_sql = f"INSERT INTO `{table_name}` ({insert_cols}) VALUES ({placeholders})"
+        elif db_type == "sqlserver":
+            # SQL Server uses square brackets
+            insert_cols = ", ".join(f"[{c}]" for c in safe_col_list)
+            placeholders = ", ".join([f":{c}" for c in safe_col_list])
+            insert_sql = f"INSERT INTO [{table_name}] ({insert_cols}) VALUES ({placeholders})"
+        elif db_type == "redshift":
+            # Redshift similar to PostgreSQL
+            insert_cols = ", ".join(f'"{c}"' for c in safe_col_list)
+            placeholders = ", ".join([f":{c}" for c in safe_col_list])
+            insert_sql = f'INSERT INTO "{table_name}" ({insert_cols}) VALUES ({placeholders})'
+        else:
+            # Default PostgreSQL style
+            insert_cols = ", ".join(f'"{c}"' for c in safe_col_list)
+            placeholders = ", ".join([f":{c}" for c in safe_col_list])
+            insert_sql = f'INSERT INTO "{table_name}" ({insert_cols}) VALUES ({placeholders})'
+
+        # Execute INSERT statements
+        try:
+            async with engine.begin() as conn:
+                rows_to_insert = []
+                for idx, row in enumerate(
+                    converted_df.replace({np.nan: None}).to_dict("records")
+                ):
+                    rows_to_insert.append(row)
+
+                    # Batch insert when chunk size reached or at the end
+                    if len(rows_to_insert) == chunksize or idx == len(converted_df) - 1:
+                        await conn.execute(text(insert_sql), rows_to_insert)
+                        rows_to_insert = []
+        except Exception as e:
+            raise Exception(f"Failed to insert data: {str(e)}")
+
+        LOGGER.info(f"Successfully imported {len(df)} rows into table '{table_name}'.")
+        return {"success": True, "inferred_types": inferred_types}
+    
+    @staticmethod
+    async def _export_df_to_bigquery(
+        df: pd.DataFrame, 
+        table_name: str, 
+        db_creds: dict, 
+        col_name_mapping: dict
+    ):
+        """
+        Export a DataFrame to BigQuery.
+        This method handles the special case for BigQuery which uses the Google Cloud SDK.
+        
+        Args:
+            df: DataFrame to export
+            table_name: Name of the target table
+            db_creds: BigQuery credentials
+            col_name_mapping: Mapping between sanitized and original column names
+            
+        Returns:
+            Dictionary with success status and inferred types
+        """
+        try:
+            from google.cloud import bigquery
+            from google.oauth2 import service_account
+        except ImportError:
+            raise Exception("Google Cloud BigQuery libraries not installed. Install with: pip install google-cloud-bigquery")
+            
+        # Extract credentials from db_creds
+        if 'json_key_path' in db_creds:
+            credentials = service_account.Credentials.from_service_account_file(
+                db_creds['json_key_path']
+            )
+        elif 'credentials_file_content' in db_creds:
+            # Write the credentials content to a temporary file
+            with tempfile.NamedTemporaryFile(mode='w', delete=False, suffix='.json') as temp_file:
+                json.dump(db_creds['credentials_file_content'], temp_file)
+                temp_path = temp_file.name
+            
+            credentials = service_account.Credentials.from_service_account_file(temp_path)
+            # Clean up the temporary file
+            os.unlink(temp_path)
+        else:
+            raise Exception("BigQuery credentials missing. Need either json_key_path or credentials_file_content.")
+            
+        # Get project_id from credentials or credentials_content
+        project_id = credentials.project_id
+        if not project_id and 'project_id' in db_creds:
+            project_id = db_creds['project_id']
+            
+        if not project_id:
+            raise Exception("Could not determine BigQuery project_id from credentials.")
+        
+        # Initialize BigQuery client
+        client = bigquery.Client(credentials=credentials, project=project_id)
+        
+        # Set dataset if provided, otherwise use default
+        dataset_id = db_creds.get('dataset', 'default_dataset')
+        table_ref = f"{project_id}.{dataset_id}.{table_name}"
+        
+        # Infer schema from DataFrame
+        inferred_types = {}
+        schema = []
+        
+        for col in df.columns:
+            original_name = col_name_mapping.get(col, col)
+            # Try to infer the BigQuery data type
+            try:
+                pg_type = TypeUtils.guess_column_type(df[col], column_name=original_name)
+                
+                # Map PostgreSQL types to BigQuery types
+                if pg_type == "TEXT":
+                    bq_type = "STRING"
+                elif pg_type in ["BIGINT", "INTEGER"]:
+                    bq_type = "INT64"
+                elif pg_type == "DOUBLE PRECISION":
+                    bq_type = "FLOAT64"
+                elif "TIMESTAMP" in pg_type:
+                    bq_type = "TIMESTAMP"
+                elif "TIME" in pg_type:
+                    bq_type = "TIME"
+                elif pg_type == "BOOLEAN":
+                    bq_type = "BOOL"
+                else:
+                    # Default to string for unknown types
+                    bq_type = "STRING"
+                
+                inferred_types[col] = bq_type
+                schema.append(bigquery.SchemaField(col, bq_type))
+            except Exception as e:
+                LOGGER.error(f"Error inferring type for {col}: {str(e)}")
+                # Default to STRING for problematic columns
+                inferred_types[col] = "STRING"
+                schema.append(bigquery.SchemaField(col, "STRING"))
+        
+        # Configure table with schema
+        table = bigquery.Table(table_ref, schema=schema)
+        
+        # Delete table if it exists
+        try:
+            client.delete_table(table_ref, not_found_ok=True)
+            LOGGER.info(f"Table {table_ref} deleted if it existed.")
+        except Exception as e:
+            LOGGER.warning(f"Error deleting table {table_ref}: {str(e)}")
+        
+        # Create the table
+        try:
+            table = client.create_table(table)
+            LOGGER.info(f"Created table {table_ref}")
+        except Exception as e:
+            raise Exception(f"Failed to create BigQuery table: {str(e)}")
+        
+        # Load data
+        try:
+            # Convert to records
+            records = df.replace({np.nan: None}).to_dict("records")
+            
+            # Insert data in chunks
+            chunk_size = 5000
+            for i in range(0, len(records), chunk_size):
+                chunk = records[i:i + chunk_size]
+                errors = client.insert_rows_json(table, chunk)
+                if errors:
+                    raise Exception(f"Error loading data to BigQuery: {errors}")
+                
+            LOGGER.info(f"Successfully loaded {len(df)} rows to BigQuery table {table_ref}")
+        except Exception as e:
+            raise Exception(f"Failed to insert data into BigQuery: {str(e)}")
+            
+        return {"success": True, "inferred_types": inferred_types}
+    
+    @staticmethod
+    async def _export_df_to_snowflake(
+        df: pd.DataFrame, 
+        table_name: str, 
+        db_connection_string: str,
+        db_creds: dict, 
+        col_name_mapping: dict
+    ):
+        """
+        Export a DataFrame to Snowflake.
+        This method handles the special case for Snowflake which may require additional parameters.
+        
+        Args:
+            df: DataFrame to export
+            table_name: Name of the target table
+            db_connection_string: Database connection string
+            db_creds: Snowflake credentials
+            col_name_mapping: Mapping between sanitized and original column names
+            
+        Returns:
+            Dictionary with success status and inferred types
+        """
+        # Create a SQLAlchemy engine using connection string
+        engine = create_async_engine(db_connection_string)
+        
+        # Infer data types using original column names
+        inferred_types = {}
+        for col in df.columns:
+            original_name = col_name_mapping.get(col, col)
+            try:
+                pg_type = TypeUtils.guess_column_type(df[col], column_name=original_name)
+                
+                # Map PostgreSQL types to Snowflake types
+                if pg_type == "DOUBLE PRECISION":
+                    sf_type = "FLOAT"
+                elif pg_type == "BIGINT":
+                    sf_type = "NUMBER"
+                else:
+                    # Most PostgreSQL types map well to Snowflake
+                    sf_type = pg_type
+                    
+                inferred_types[col] = sf_type
+            except Exception as e:
+                raise Exception(f"Failed to infer type for column {original_name}: {e}")
+        
+        # Create table schema
+        try:
+            create_stmt = DbUtils.create_table_sql(table_name, inferred_types, "snowflake")
+        except Exception as e:
+            raise Exception(f"Failed to create Snowflake table schema: {str(e)}")
+            
+        # Convert values (using postgres converter as a base)
         converted_df = df.copy()
         for col in df.columns:
             try:
@@ -180,39 +538,62 @@ class DbUtils:
                     )
                 )
             except Exception as e:
-                raise Exception(
-                    f"Failed to convert values to PostgreSQL type for column {col} in table {table_name}: {e}"
-                )
-
-        # Create table in PostgreSQL
+                raise Exception(f"Failed to convert values for column {col}: {e}")
+                
+        # Execute DROP and CREATE
         try:
-            create_stmt = DbUtils.create_table_sql(table_name, inferred_types)
+            async with engine.begin() as conn:
+                # Snowflake uses double quotes for identifiers
+                await conn.execute(text(f'DROP TABLE IF EXISTS "{table_name}";'))
+                await conn.execute(text(create_stmt))
         except Exception as e:
-            raise Exception(
-                f"Failed to create CREATE TABLE statements for {table_name}: {e}"
-            )
-        async with engine.begin() as conn:
-            await conn.execute(text(f'DROP TABLE IF EXISTS "{table_name}";'))
-            await conn.execute(text(create_stmt))
-
-        # Prepare and execute INSERT statements
-        insert_cols = ", ".join(f'"{c}"' for c in safe_col_list)
-        placeholders = ", ".join([f":{c}" for c in safe_col_list])
-        insert_sql = (
-            f'INSERT INTO "{table_name}" ({insert_cols}) VALUES ({placeholders})'
-        )
-
-        async with engine.begin() as conn:
-            rows_to_insert = []
-            for idx, row in enumerate(
-                converted_df.replace({np.nan: None}).to_dict("records")
-            ):
-                rows_to_insert.append(row)
-
-                # Batch insert when chunk size reached or at the end
-                if len(rows_to_insert) == chunksize or idx == len(converted_df) - 1:
-                    await conn.execute(text(insert_sql), rows_to_insert)
-                    rows_to_insert = []
-
-        print(f"Successfully imported {len(df)} rows into table '{table_name}'.")
+            raise Exception(f"Failed to create Snowflake table: {str(e)}")
+            
+        # Prepare and execute INSERT
+        try:
+            insert_cols = ", ".join(f'"{c}"' for c in df.columns)
+            placeholders = ", ".join([f":{c}" for c in df.columns])
+            insert_sql = f'INSERT INTO "{table_name}" ({insert_cols}) VALUES ({placeholders})'
+            
+            async with engine.begin() as conn:
+                rows_to_insert = []
+                chunk_size = 5000
+                
+                for idx, row in enumerate(
+                    converted_df.replace({np.nan: None}).to_dict("records")
+                ):
+                    rows_to_insert.append(row)
+                    
+                    # Batch insert when chunk size reached or at the end
+                    if len(rows_to_insert) == chunk_size or idx == len(converted_df) - 1:
+                        await conn.execute(text(insert_sql), rows_to_insert)
+                        rows_to_insert = []
+        except Exception as e:
+            raise Exception(f"Failed to insert data into Snowflake: {str(e)}")
+            
+        LOGGER.info(f"Successfully imported {len(df)} rows into Snowflake table '{table_name}'.")
         return {"success": True, "inferred_types": inferred_types}
+        
+    @staticmethod
+    async def export_df_to_postgres(
+        df: pd.DataFrame,
+        table_name: str,
+        db_connection_string: str,
+        chunksize: int = 5000,
+    ):
+        """
+        Export a pandas DataFrame to PostgreSQL (legacy method).
+        This method is maintained for backward compatibility.
+        
+        Args:
+            df: DataFrame to export
+            table_name: Name of the target table
+            db_connection_string: Database connection string
+            chunksize: Number of rows to insert at once
+
+        Returns:
+            Dictionary with success status and inferred types
+        """
+        return await DbUtils.export_df_to_db(
+            df, table_name, db_connection_string, "postgres", chunksize
+        )

--- a/backend/utils_file_uploads/legacy.py
+++ b/backend/utils_file_uploads/legacy.py
@@ -54,9 +54,18 @@ def convert_values_to_postgres_type(value, target_type: str):
     return TypeUtils.convert_values_to_postgres_type(value, target_type)
 
 
-def create_table_sql(table_name: str, columns: dict[str, str]):
+def create_table_sql(table_name: str, columns: dict[str, str], db_type: str = "postgres"):
     """Legacy wrapper for DbUtils.create_table_sql"""
-    return DbUtils.create_table_sql(table_name, columns)
+    return DbUtils.create_table_sql(table_name, columns, db_type)
+
+
+async def export_df_to_db(
+    df, table_name: str, db_connection_string: str, db_type: str = "postgres", chunksize: int = 5000, db_creds: dict = None
+):
+    """Legacy wrapper for DbUtils.export_df_to_db"""
+    return await DbUtils.export_df_to_db(
+        df, table_name, db_connection_string, db_type, chunksize, db_creds
+    )
 
 
 async def export_df_to_postgres(

--- a/frontend/pages/log-in.js
+++ b/frontend/pages/log-in.js
@@ -100,7 +100,7 @@ const LogIn = () => {
                     id="username"
                     name="username"
                     type="text"
-                    defaultValue={"ADMIN"}
+                    defaultValue={"admin"}
                     required
                     autoComplete="username"
                     className="block w-full rounded-md border-0 py-1.5 text-gray-900 dark:text-dark-text-primary shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-dark-border dark:bg-dark-bg-secondary placeholder:text-gray-400 dark:placeholder:text-gray-600 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm sm:leading-6"
@@ -133,7 +133,7 @@ const LogIn = () => {
                     required
                     autoComplete="current-password"
                     className="block w-full rounded-md border-0 py-1.5 text-gray-900 dark:text-dark-text-primary shadow-sm ring-1 ring-inset ring-gray-300 dark:ring-dark-border dark:bg-dark-bg-secondary placeholder:text-gray-400 dark:placeholder:text-gray-600 focus:ring-2 focus:ring-inset focus:ring-blue-600 sm:text-sm sm:leading-6"
-                    defaultValue={"ADMIN"}
+                    defaultValue={"admin"}
                   />
                 </div>
               </div>


### PR DESCRIPTION
Previously, if a user had already selected a database (like, say, an internal postgres or mysql DB) but wanted to export an added CSV to it – they can't do it. Instead, the CSV is added to our internal DB.

This was confusing and a bad user experience. We now let users add the CSV _directly_ to their database if a database is selected, instead of writing to our internal database.

Verified that this works on both redshift and postgres. Not yet verified for other DBs