### PR TITLE
DEF-794 Backend for PDF searching in fast analyses

### DIFF
--- a/backend/query_data/data_fetching.py
+++ b/backend/query_data/data_fetching.py
@@ -47,7 +47,6 @@ async def data_fetcher_and_aggregator(
         db_type, db_creds = db_creds_result
         err = None
 
-        print(f"Previous context: {previous_context}", flush=True)
 
         # generate SQL
         res = await generate_sql_query(

--- a/backend/query_data_models.py
+++ b/backend/query_data_models.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, Optional, List
 from pydantic import BaseModel
 
 
@@ -19,6 +19,27 @@ class PreviousContextItem(BaseModel):
     sql: str
 
 
+class PDFSearchRequest(BaseModel):
+    analysis_id: str
+    
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "analysis_id": "your-analysis-id"
+                }
+            ]
+        }
+    }
+    
+
+class PDFSearchResponse(BaseModel):
+    success: bool
+    pdf_results: Optional[List] = []
+    message: Optional[str] = None
+    error_message: Optional[str] = None
+
+
 class AnalysisData(BaseModel):
     analysis_id: str
     db_name: str
@@ -31,6 +52,7 @@ class AnalysisData(BaseModel):
     sql: Optional[str] = None
     output: Optional[str] = None
     error: Optional[str] = None
+    pdf_search_results: Optional[list] = None
 
 
 class RerunEditedInputs(BaseModel):

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,6 +12,7 @@ openpyxl
 pandas==2.2.3
 pgvector==0.3.6
 python-multipart
+pymupdf
 pyyaml
 redis
 requests

--- a/backend/tests/backend_routes/test_db.sql
+++ b/backend/tests/backend_routes/test_db.sql
@@ -5,15 +5,13 @@ CREATE TABLE IF NOT EXISTS customers (
     email VARCHAR(255) UNIQUE NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
-
 CREATE TABLE IF NOT EXISTS ticket_types (
     id SERIAL PRIMARY KEY,
     name VARCHAR(50) NOT NULL,
     description TEXT,
-    price DECIMAL(10,2) NOT NULL,
+    price DECIMAL(10, 2) NOT NULL,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
-
 CREATE TABLE IF NOT EXISTS ticket_sales (
     id SERIAL PRIMARY KEY,
     customer_id INTEGER REFERENCES customers(id),
@@ -22,30 +20,27 @@ CREATE TABLE IF NOT EXISTS ticket_sales (
     valid_until TIMESTAMP,
     status VARCHAR(20) DEFAULT 'active' CHECK (status IN ('active', 'used', 'expired'))
 );
-
 -- Insert sample data
-INSERT INTO customers (name, email) VALUES
-    ('John Doe', 'john@example.com'),
+INSERT INTO customers (name, email)
+VALUES ('John Doe', 'john@example.com'),
     ('Jane Smith', 'jane@example.com'),
     ('Bob Wilson', 'bob@example.com'),
-    ('Alice Brown', 'alice@example.com')
-ON CONFLICT (email) DO NOTHING;
-
-INSERT INTO ticket_types (name, description, price) VALUES
-    ('Standard', 'Regular admission ticket', 50.00),
+    ('Alice Brown', 'alice@example.com') ON CONFLICT (email) DO NOTHING;
+INSERT INTO ticket_types (name, description, price)
+VALUES ('Standard', 'Regular admission ticket', 50.00),
     ('VIP', 'VIP access with special perks', 150.00),
-    ('Student', 'Discounted ticket for students', 25.00)
-ON CONFLICT DO NOTHING;
-
+    (
+        'Student',
+        'Discounted ticket for students',
+        25.00
+    ) ON CONFLICT DO NOTHING;
 -- Insert sample ticket sales
 INSERT INTO ticket_sales (customer_id, ticket_type_id, valid_until, status)
-SELECT 
-    c.id,
+SELECT c.id,
     tt.id,
     CURRENT_TIMESTAMP + INTERVAL '30 days',
     'active'
 FROM customers c
-CROSS JOIN ticket_types tt
+    CROSS JOIN ticket_types tt
 WHERE c.email IN ('john@example.com', 'jane@example.com')
-AND tt.name IN ('Standard', 'VIP')
-ON CONFLICT DO NOTHING;
+    AND tt.name IN ('Standard', 'VIP') ON CONFLICT DO NOTHING;

--- a/backend/tests/backend_routes/test_pdf_search.py
+++ b/backend/tests/backend_routes/test_pdf_search.py
@@ -1,0 +1,175 @@
+import pytest
+import os
+import uuid
+from fastapi.testclient import TestClient
+import requests
+
+from main import app
+from .conftest import BASE_URL, TEST_DB, create_pdf_and_get_base_64
+
+client = TestClient(app)
+
+
+def test_pdf_search_workflow(admin_token):
+    """Test the complete PDF search workflow:
+    1. Upload PDF files
+    2. Create an analysis
+    3. Generate analysis step
+    4. Run PDF search on the analysis
+    """
+    # Step 1: Create and upload PDF files with relevant content
+    # Create first PDF with content about VIP tickets
+    pdf1_name, pdf1_path, pdf1_base64 = create_pdf_and_get_base_64([
+        "This is a test PDF document for testing the SQL-PDF search feature.",
+        "It contains information about ticket prices.",
+        "VIP tickets cost $150 and include special perks.",
+        "Standard tickets cost $50 for regular admission."
+    ])
+    
+    # Create second PDF with content about ticket sales
+    pdf2_name, pdf2_path, pdf2_base64 = create_pdf_and_get_base_64([
+        "This is another test PDF for SQL-PDF search.",
+        "Information about ticket sales data.",
+        "VIP tickets have been selling well among corporate clients.",
+        "Student tickets at $25 are popular among younger audiences."
+    ])
+    
+    pdf_ids = []
+    
+    try:
+        # Upload first PDF
+        with open(pdf1_path, 'rb') as pdf_file:
+            files = [
+                ('files', (pdf1_name, pdf_file, 'application/pdf'))
+            ]
+            form_data = {
+                'token': admin_token,
+                'db_name': TEST_DB["db_name"]
+            }
+            
+            response = requests.post(
+                f"{BASE_URL}/upload_files",
+                files=files,
+                data=form_data
+            )
+        
+        assert response.status_code == 200
+        upload_result = response.json()
+        assert "message" in upload_result
+        assert upload_result["message"] == "Success"
+        assert "db_name" in upload_result
+        assert upload_result["db_name"] == TEST_DB["db_name"]
+        assert "db_info" in upload_result
+        
+        # Upload second PDF
+        with open(pdf2_path, 'rb') as pdf_file:
+            files = [
+                ('files', (pdf2_name, pdf_file, 'application/pdf'))
+            ]
+            form_data = {
+                'token': admin_token,
+                'db_name': TEST_DB["db_name"]
+            }
+            
+            response = requests.post(
+                f"{BASE_URL}/upload_files",
+                files=files,
+                data=form_data
+            )
+        
+        assert response.status_code == 200
+        upload_result = response.json()
+        assert "message" in upload_result
+        assert upload_result["message"] == "Success"
+        assert "db_name" in upload_result
+        assert upload_result["db_name"] == TEST_DB["db_name"]
+        assert "db_info" in upload_result
+
+        pdf_ids = [x["file_id"] for x in upload_result["db_info"]["associated_files"]]
+        
+        # Step 2: Create an analysis
+        analysis_id = str(uuid.uuid4())
+        create_analysis_response = requests.post(
+            f"{BASE_URL}/query-data/create_analysis",
+            json={
+                "token": admin_token,
+                "db_name": TEST_DB["db_name"],
+                "custom_id": analysis_id,
+                "initialisation_details": {
+                    "user_question": "What are the prices of VIP tickets?"
+                }
+            }
+        )
+        
+        assert create_analysis_response.status_code == 200
+        analysis = create_analysis_response.json()
+        assert analysis["analysis_id"] == analysis_id
+        
+        # Step 3: Generate analysis step (SQL query)
+        generate_response = requests.post(
+            f"{BASE_URL}/query-data/generate_analysis",
+            json={
+                "token": admin_token,
+                "db_name": TEST_DB["db_name"],
+                "analysis_id": analysis_id,
+                "user_question": "What are the prices of VIP tickets?"
+            }
+        )
+        
+        assert generate_response.status_code == 200
+        generated_analysis = generate_response.json()
+        assert generated_analysis["data"]["sql"] is not None
+        assert "VIP" in generated_analysis["data"]["sql"] or "vip" in generated_analysis["data"]["sql"]
+        
+        # Step 4: Run PDF search on the analysis
+        pdf_search_response = requests.post(
+            f"{BASE_URL}/query-data/pdf_search",
+            json={
+                "analysis_id": analysis_id,
+                "token": admin_token,
+            },
+        )
+        
+        assert pdf_search_response.status_code == 200
+        pdf_search_result = pdf_search_response.json()
+        assert pdf_search_result.get("success") is True
+        assert "pdf_results" in pdf_search_result
+        assert "analysis" in pdf_search_result
+        
+        # Verify the analysis contains the PDF search results
+        updated_analysis = pdf_search_result["analysis"]
+        assert "pdf_search_results" in updated_analysis["data"]
+        assert updated_analysis["data"]["pdf_search_results"] is not None
+        
+        # Print the PDF search results for debugging
+        print("PDF Search Results:", pdf_search_result["pdf_results"])
+    
+    finally:
+        # Clean up temporary PDF files
+        for path in [pdf1_path, pdf2_path]:
+            if os.path.exists(path):
+                os.remove(path)
+        for file_id in pdf_ids:
+            # remove the pdfs from the db
+            # call the /delete_pdf/{file_id} route
+            delete_pdf_response = requests.delete(f"{BASE_URL}/delete_pdf/{file_id}?token={admin_token}&db_name={TEST_DB['db_name']}")
+            assert delete_pdf_response.status_code == 200
+
+
+
+def test_pdf_search_invalid_analysis(admin_token):
+    """Test the PDF search endpoint with an invalid analysis ID"""
+    invalid_id = "nonexistent-analysis-id"
+    response = requests.post(
+        f"{BASE_URL}/query-data/pdf_search",
+        json={"analysis_id": invalid_id, "token": admin_token},
+    )
+    
+    assert response.status_code == 500
+    data = response.json()
+    assert data.get("success") is False
+    assert "error_message" in data
+
+
+if __name__ == "__main__":
+    pytest.main(["-xvs", __file__])

--- a/backend/tests/backend_routes/test_pdf_search.py
+++ b/backend/tests/backend_routes/test_pdf_search.py
@@ -154,22 +154,3 @@ def test_pdf_search_workflow(admin_token):
             # call the /delete_pdf/{file_id} route
             delete_pdf_response = requests.delete(f"{BASE_URL}/delete_pdf/{file_id}?token={admin_token}&db_name={TEST_DB['db_name']}")
             assert delete_pdf_response.status_code == 200
-
-
-
-def test_pdf_search_invalid_analysis(admin_token):
-    """Test the PDF search endpoint with an invalid analysis ID"""
-    invalid_id = "nonexistent-analysis-id"
-    response = requests.post(
-        f"{BASE_URL}/query-data/pdf_search",
-        json={"analysis_id": invalid_id, "token": admin_token},
-    )
-    
-    assert response.status_code == 500
-    data = response.json()
-    assert data.get("success") is False
-    assert "error_message" in data
-
-
-if __name__ == "__main__":
-    pytest.main(["-xvs", __file__])

--- a/backend/tests/backend_routes/test_pdfs/test_pdf1.pdf
+++ b/backend/tests/backend_routes/test_pdfs/test_pdf1.pdf
@@ -1,0 +1,38 @@
+%PDF-1.7
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 4 0 R >> >> /MediaBox [0 0 612 792] /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length 142 >>
+stream
+BT
+/F1 12 Tf
+100 700 Td
+(This is a test PDF for SQL-PDF search feature.) Tj
+100 680 Td
+(It mentions tickets for VIP customers costing $150.) Tj
+ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f
+0000000010 00000 n
+0000000059 00000 n
+0000000118 00000 n
+0000000251 00000 n
+0000000319 00000 n
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+511
+%%EOF

--- a/backend/tests/backend_routes/test_pdfs/test_pdf2.pdf
+++ b/backend/tests/backend_routes/test_pdfs/test_pdf2.pdf
@@ -1,0 +1,38 @@
+%PDF-1.7
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /Resources << /Font << /F1 4 0 R >> >> /MediaBox [0 0 612 792] /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+5 0 obj
+<< /Length 142 >>
+stream
+BT
+/F1 12 Tf
+100 700 Td
+(This is a test PDF for SQL-PDF search feature.) Tj
+100 680 Td
+(It mentions information about ticket sales and prices costing $150.) Tj
+ET
+endstream
+endobj
+xref
+0 6
+0000000000 65535 f
+0000000010 00000 n
+0000000059 00000 n
+0000000118 00000 n
+0000000251 00000 n
+0000000319 00000 n
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+511
+%%EOF


### PR DESCRIPTION
This is a more concise version of [this](https://github.com/defog-ai/introspect/pull/467) PR. We now use anthropic's citations api to return pdf search results.


Major changes:
1. add pymupdf to requirements (this is _really_ useful for testing. Helps us create arbitrary pdf files without worrying about writing raw pdfs.)
2. added `query-data/pdf_search` route which takes in an `analysis_id`.
3. added test for a pdf search route which creates a couple pdfs, runs an analysis and then calls the pdf search route for that analysis
4. added inserting metadata for test_db in `conftest`'s setup (useful for creating new anlayses)

Not rigged to the frontend yet.

Tests (claude is down as of creating this PR so these will fail for now):
```
docker exec introspect-backend pytest tests/backend_routes/test_pdf_search.py -sv
```

This test will:
1. Creates two pdfs and uploads them
2. Starts an analysis with a simple question
3. Then runs citation search for that analysis

Keeping this ðraft till the citations API is up again