### PR TITLE
Add /oracle/export_podcast endpoint for generating podcast transcripts

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@codemirror/lang-sql": "^6.7.0",
-    "@defogdotai/agents-ui-components": "1.10.4",
+    "@defogdotai/agents-ui-components": "1.10.6",
     "@react-oauth/google": "^0.12.1",
     "@types/react-dom": "19.0.0",
     "lodash.debounce": "^4.0.8",


### PR DESCRIPTION
## Summary
- Added new backend endpoint  that converts Oracle report MDX content into a podcast transcript format between two hosts
- Uses gemini-2.5-pro to create a conversational dialogue based on the report content
- This is a sister PR to agents-ui-components https://github.com/defog-ai/agents-ui-components/pull/200 which implements the frontend component

## Test plan
1. Start the backend server
2. Use the frontend to trigger a podcast export from any Oracle report
3. Verify the endpoint successfully processes the report and returns a transcript
4. Check the transcript content to ensure it follows the conversation format

🤖 Generated with [Claude Code](https://claude.ai/code)