### PR TITLE
Update generator and critic model used in multi-agent report generation to o4-mini

### DIFF
--- a/backend/oracle_routes.py
+++ b/backend/oracle_routes.py
@@ -250,7 +250,6 @@ async def generate_report(req: GenerateReportRequest):
         LOGGER.info("Using multi-agent approach for report generation")
         analysis_response = await multi_agent_report_generation(
             db_name=db_name,
-            model="claude-3-7-sonnet-latest",
             question=user_question,
             clarification_responses=clarification_responses,
             post_tool_func=post_tool_func,

--- a/backend/tools/analysis_tools.py
+++ b/backend/tools/analysis_tools.py
@@ -742,7 +742,6 @@ async def generate_report_with_agents(
 
 async def multi_agent_report_generation(
     db_name: str,
-    model: str,
     question: str,
     clarification_responses: str,
     post_tool_func: Callable,
@@ -787,7 +786,7 @@ async def multi_agent_report_generation(
         
         # PHASE 1: DATA COLLECTION & ANALYSIS
         analyst_response = await chat_async(
-            model=model,
+            model="o4-mini",
             tools=tools,
             messages=[
                 {
@@ -845,7 +844,7 @@ DATA ANALYSIS FINDINGS:
 """
         
         evaluator_response = await chat_async(
-            model=model,
+            model="o4-mini",
             tools=tools,
             messages=[
                 {


### PR DESCRIPTION
This makes report generation faster, cheaper, and more concise.

We still use claude 3.7 sonnet for the final step (the actual report gen). But use o4-mini for Phase 1 (initial report generation) and Phase 2 (figuring out gaps in the report). This is because neither OpenAI nor Gemini have a proper citations API yet.