### PR TITLE
Fix CWE-94 in analysis tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 Introspect is a service that does data-focused deep research for structured data. It understands your structured data (databases or CSV/Excel files), unstructured data (PDFs), and can query the web to get additional context.
 
 ## Demo
-- Interactive Demo: https://demo.defog.ai/reports (user id: `admin`, password: `admin`)
 - [150s video](https://www.loom.com/share/ed2017d503ce4335909f47e8629a3acb)
 
 ## Quick Start
@@ -61,8 +60,9 @@ Defog supports most database connectors including PostgreSQL, MySQL, SQLite, Big
 - Run frontend tests: `cd frontend && npx playwright test`
 - Lint (Prettier): `cd frontend && npm run lint`
 
-## Docs
-Coming soon
+## Security
+- It is highly recommended to run this only as a Docker image, for security purposes
+- This repo does involve code where LLM generated code (or custom human generated code) can be autonomously executed. While we have implemented some safeguards to prevent abuse, safety is not guaranteed outside a docker environment.
 
 ## Contributing and Maintainers
 This repo is maintained by Defog.ai

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,6 +1,6 @@
 boto3
 colorama
-defog==0.68.3
+defog==0.68.4
 fastapi
 google-auth
 httpx

--- a/backend/tests/test_code_interpreter.py
+++ b/backend/tests/test_code_interpreter.py
@@ -24,7 +24,7 @@ TEST_DB = {
     },
 }
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(loop_scope="session")
 async def test_code_interpreter_advanced_statistics():
     """
     Test the code_interpreter_tool's ability to perform advanced statistical calculations
@@ -39,7 +39,7 @@ async def test_code_interpreter_advanced_statistics():
     
     # Call the code_interpreter_tool
     result = await code_interpreter_tool(input_data)
-    
+
     # Verify the response structure
     assert "analysis_id" in result, "Missing analysis_id in result"
     assert "question" in result, "Missing question in result"
@@ -50,15 +50,14 @@ async def test_code_interpreter_advanced_statistics():
     code = result["code"]
     assert "z_score" in code or "zscore" in code, "Code does not contain z-score calculation"
     assert "std" in code, "Code does not contain standard deviation calculation"
-    
+
     # Verify the result contains z-score related information
     result_text = result["result"]
-    assert any(term in result_text.lower() for term in ["z-score", "zscore", "standard deviation", "outlier"]), "Result does not contain z-score analysis"
-    
     print(f"\nTest result preview: {result_text[:200]}...")
+    assert any(term in result_text.lower() for term in ["z-score", "zscore", "standard deviation", "outlier"]), "Result does not contain z-score analysis"
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(loop_scope="session")
 async def test_code_interpreter_probability_analysis():
     """
     Test the code_interpreter_tool's ability to perform probability calculations
@@ -85,7 +84,7 @@ async def test_code_interpreter_probability_analysis():
     print(f"\nTest result preview: {result_text[:200]}...")
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(loop_scope="session")
 async def test_code_interpreter_correlation_analysis():
     """
     Test the code_interpreter_tool's ability to perform correlation analysis
@@ -112,7 +111,7 @@ async def test_code_interpreter_correlation_analysis():
     print(f"\nTest result preview: {result_text[:200]}...")
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(loop_scope="session")
 async def test_code_interpreter_custom_formula():
     """
     Test the code_interpreter_tool's ability to apply custom business formulas
@@ -140,7 +139,7 @@ async def test_code_interpreter_custom_formula():
     print(f"\nTest result preview: {result_text[:200]}...")
 
 
-@pytest.mark.asyncio
+@pytest.mark.asyncio(loop_scope="session")
 async def test_code_interpreter_time_series():
     """
     Test the code_interpreter_tool's ability to perform time series analysis
@@ -161,5 +160,6 @@ async def test_code_interpreter_time_series():
     
     # Verify result discusses time series components
     result_text = result["result"]
+    assert any(term in result_text.lower() for term in ["time series", "trend", "seasonal", "residual", "forecast"]), "Result does not contain time series analysis"
     
     print(f"\nTest result preview: {result_text[:200]}...")

--- a/backend/tests/test_code_interpreter_security.py
+++ b/backend/tests/test_code_interpreter_security.py
@@ -1,0 +1,118 @@
+"""Tests for the code_interpreter_tool security enhancements."""
+
+import pytest
+import asyncio
+import json
+import sys
+import os
+import pandas as pd
+
+# Import directly from the backend
+from tools.analysis_tools import execute_analysis_code_safely
+
+@pytest.mark.asyncio
+async def test_file_system_access_restriction():
+    """
+    Test that execute_analysis_code_safely properly restricts file system access
+    to only the /tmp directory as specified.
+    """
+    # PoC exploit attempt - try to read /etc/passwd
+    malicious_code = """
+import pandas as pd
+try:
+    data = pd.read_csv('/etc/passwd', sep=':', header=None)
+    final_result = f"SUCCESS: Was able to read {len(data)} lines from /etc/passwd"
+except Exception as e:
+    final_result = f"Error: {str(e)}"
+"""
+    
+    # Execute the code in the secured environment
+    result_text, error_message = await execute_analysis_code_safely(malicious_code, "[]")
+    
+    print(result_text)
+    print(error_message)
+
+    # Verify the code was prevented from accessing the sensitive file
+    # The test now checks that we don't see "SUCCESS" which would indicate the exploit worked
+    assert "SUCCESS" not in result_text, \
+        "Security bypass - code was able to read sensitive file"
+    assert "not permitted" in error_message, \
+        "Should return an error when accessing unauthorized paths"
+
+@pytest.mark.asyncio
+async def test_tmp_directory_access_allowed():
+    """
+    Test that execute_analysis_code_safely allows file system access
+    to the /tmp directory as expected.
+    """
+    # Create a test file in /tmp
+    test_data = {'A': [1, 2, 3], 'B': [4, 5, 6]}
+    test_df = pd.DataFrame(test_data)
+    tmp_file = '/tmp/test_secure_access.csv'
+    test_df.to_csv(tmp_file, index=False)
+    
+    # Code that tries to access the file in /tmp
+    allowed_code = """
+import pandas as pd
+try:
+    # This should be allowed since it's in /tmp
+    data = pd.read_csv('/tmp/test_secure_access.csv')
+    final_result = f"Success! Data read from /tmp: {data.shape[0]} rows, {data.shape[1]} columns"
+except Exception as e:
+    final_result = f"Error: {str(e)}"
+"""
+    
+    try:
+        # Execute the code in the secured environment
+        result_text, error_message = await execute_analysis_code_safely(allowed_code, "[]")
+
+        print(result_text)
+        print(error_message)
+        
+        # Verify the code was allowed to access the file in /tmp
+        assert "Success" in result_text, \
+            "Access to /tmp should be allowed but was blocked"
+        assert "3 rows" in result_text, \
+            "Test data should be correctly read from the file"
+    finally:
+        # Clean up
+        try:
+            os.remove(tmp_file)
+        except:
+            pass
+
+@pytest.mark.asyncio
+async def test_normal_analysis_still_works():
+    """
+    Test that execute_analysis_code_safely still allows legitimate analysis
+    code to run correctly.
+    """
+    # Normal analysis code
+    analysis_code = """
+import pandas as pd
+import numpy as np
+
+# Create a sample DataFrame
+data = {'A': np.random.rand(100), 
+        'B': np.random.rand(100),
+        'C': np.random.randint(0, 5, 100)}
+df = pd.DataFrame(data)
+
+# Perform some analysis
+stats = df.describe()
+correlation = df.corr()
+
+# Format the result
+final_result = f"Statistics:\\n{stats}\\n\\nCorrelation:\\n{correlation}"
+"""
+    
+    # Execute the code in the secured environment
+    result_text, error_message = await execute_analysis_code_safely(analysis_code, "[]")
+    
+    # Verify the analysis ran successfully
+    assert "Statistics" in result_text, \
+        "Legitimate analysis code should run successfully"
+    assert "Correlation" in result_text, \
+        "Legitimate analysis code should produce expected output"
+    assert error_message == "", \
+        "No errors should be reported for legitimate code"


### PR DESCRIPTION
## Summary
- restrict builtins and imports when executing analysis code
- validate user supplied code using `ast`
- address #495, though not a full fledged fix

## Testing
- `pytest -k code_interpreter_tool -q`